### PR TITLE
Fix subagent architecture in team-manager and team-member roles (#1)

### DIFF
--- a/roles/team-manager.md
+++ b/roles/team-manager.md
@@ -25,7 +25,7 @@ When you first start, do the following:
 
 1. **Decide what to do next** — Assess the current state of the project: which issues are done, which are in progress, which are blocked, and which are ready for work. Use this to determine which tasks need to be delegated.
 
-2. **Delegate tasks** — Spawn a team member and use the `message` tool to explicitly assign them a task. Always assign directly — never leave tasks on the shared list for team members to self-claim. Before spawning, read the task file and extract the `model:` value from its YAML frontmatter; use that model when spawning the teammate. Always use `subagent_type: "general-purpose"` when calling the Agent tool — never `"team-member"` or any other value. Use this schema:
+2. **Delegate tasks** — Spawn a team member using the Agent tool and include the task assignment in the spawn prompt. Always assign directly — never leave tasks on the shared list for team members to self-claim. Before spawning, read the task file and extract the `model:` value from its YAML frontmatter; use that model when spawning the teammate. Always use `subagent_type: "general-purpose"` when calling the Agent tool — never `"team-member"` or any other value. Include this schema in the prompt:
 
    ```
    type: task-assignment
@@ -34,7 +34,7 @@ When you first start, do the following:
    context: <any additional context needed>
    ```
 
-3. **React to reports** — Team members report back via direct message when a task is complete or blocked. When a report arrives, decide the next action:
+3. **React to reports** — Team members report back via their final return value when a task is complete or blocked. When a report arrives, decide the next action:
    - A triage report comes in with a valid `next_issue` → delegate a planning task for that issue.
    - A triage report comes in with `next_issue: null` → check whether any non-Done issues remain. If all issues are Done, proceed to Shutdown. If blocked issues remain, report to the user that all remaining work is blocked, list each blocked issue and its blocker, and wait for direction before doing anything else.
    - A `plan-report` comes in → route based on `next_task`:

--- a/roles/team-member.md
+++ b/roles/team-member.md
@@ -11,17 +11,17 @@ You receive **tasks** from the team manager and execute them end-to-end.
 
 ## How It Works
 
-1. **Receive a task** — The team manager explicitly assigns you a task via a direct message. Wait to be assigned — never self-claim tasks from the shared task list.
+1. **Receive a task** — The team manager explicitly assigns you a task in the spawn prompt. Wait to be assigned — never self-claim tasks from the shared task list.
 2. **Load the task definition** — Read the corresponding file from the `tasks/` folder. It contains the step-by-step workflow for that task.
 3. **Execute the task** — Follow the task workflow. Use your judgment where the steps require it.
-4. **Report back** — When the task is complete or if you are blocked, use the `message` tool to message `team-manager`. Use the schema defined in the task file for completion reports. Use the `blocked` schema (defined in Rules below) when blocked.
+4. **Report back** — When the task is complete or if you are blocked, include the report in your final response. Use the schema defined in the task file for completion reports. Use the `blocked` schema (defined in Rules below) when blocked.
 
 ## Rules
 
 - Only work on your assigned task — do not take on additional work outside your scope.
-- Never self-claim tasks. You only start work when `team-manager` explicitly assigns you a task via direct message.
+- Never self-claim tasks. You only start work when `team-manager` explicitly assigns you a task in the spawn prompt.
 - Always read files before editing them.
-- If you are blocked, use the `message` tool to notify `team-manager` immediately using this schema. Then stop and wait for a response.
+- If you are blocked, include the blocked report in your final response immediately using this schema. Then stop.
 
   ```
   type: blocked


### PR DESCRIPTION
## Summary

- Replaced `message` tool references in `roles/team-manager.md` with subagent-compatible patterns: task assignment goes in the Agent spawn prompt, reports come back via the team member's final return value
- Replaced `message` tool references in `roles/team-member.md` with subagent-compatible patterns: tasks are received via the spawn prompt, reports (completion and blocked) are included in the final response
- All 39 static eval tests pass

Fixes #1

## Test plan

- [x] Verify no references to `message` tool remain in role definitions (`grep` confirms zero matches)
- [x] Run `evals/test_static.py` — all 39 tests pass
- [x] Confirm team-manager delegation section describes spawn prompt pattern
- [x] Confirm team-member report section describes final response pattern
- [x] Confirm team-member blocked rule describes final response pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)