### PR TITLE
Stop idle team members automatically via TeammateIdle hook

### DIFF
--- a/evals/test_static.py
+++ b/evals/test_static.py
@@ -8,6 +8,7 @@ These tests verify that the task definition files are internally consistent:
 - Every task defines an output report schema
 - The team manager handles every report type any task can produce
 - Every task and role specifies the correct model in its frontmatter
+- The installer configures the TeammateIdle hook to stop idle teammates
 """
 import re
 from pathlib import Path
@@ -262,3 +263,32 @@ class TestModelSpecification:
             assert model in VALID_MODELS, (
                 f"{path} specifies unknown model '{model}'; must be one of {sorted(VALID_MODELS)}"
             )
+
+
+def _load_required_settings():
+    """Parse REQUIRED_SETTINGS from lib/install.js using AST-free text extraction."""
+    install_js = (REPO_ROOT / "lib" / "install.js").read_text()
+    return install_js
+
+
+class TestIdleTeammateHook:
+    """The installer must configure TeammateIdle so idle teammates are stopped automatically."""
+
+    def test_required_settings_includes_teammate_idle_hook(self):
+        install_js = _load_required_settings()
+        assert "TeammateIdle" in install_js, (
+            "lib/install.js REQUIRED_SETTINGS must include a TeammateIdle hook "
+            "to automatically stop idle team members"
+        )
+
+    def test_idle_hook_stops_teammate(self):
+        install_js = _load_required_settings()
+        assert re.search(r'"continue"\s*:\s*false', install_js), (
+            'lib/install.js TeammateIdle hook must output {"continue": false} to stop idle teammates'
+        )
+
+    def test_team_manager_role_mentions_idle_hook(self):
+        content = load_file("roles/team-manager.md")
+        assert "TeammateIdle" in content or "idle" in content.lower(), (
+            "roles/team-manager.md must document that idle team members are removed after reporting"
+        )

--- a/lib/install.js
+++ b/lib/install.js
@@ -24,7 +24,32 @@ const SETTINGS_PATH = '.claude/settings.json';
 const REQUIRED_SETTINGS = {
   env: { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1' },
   teammateMode: 'tmux',
+  hooks: {
+    TeammateIdle: [
+      {
+        hooks: [
+          {
+            type: 'command',
+            command: 'echo \'{"continue": false}\'',
+          },
+        ],
+      },
+    ],
+  },
 };
+
+function mergeHooks(existing, required) {
+  if (!existing) return required;
+  const merged = { ...existing };
+  for (const [event, matchers] of Object.entries(required)) {
+    if (!merged[event]) {
+      merged[event] = matchers;
+    }
+    // If the event already has entries, leave them as-is to avoid duplicating
+    // the stop hook on repeated installs.
+  }
+  return merged;
+}
 
 function mergeSettings(projectRoot, dryRun) {
   const settingsPath = path.join(projectRoot, SETTINGS_PATH);
@@ -36,6 +61,7 @@ function mergeSettings(projectRoot, dryRun) {
     ...existing,
     ...REQUIRED_SETTINGS,
     env: { ...existing.env, ...REQUIRED_SETTINGS.env },
+    hooks: mergeHooks(existing.hooks, REQUIRED_SETTINGS.hooks),
   };
 
   const action = fs.existsSync(settingsPath) ? 'updated' : 'installed';
@@ -132,7 +158,10 @@ function status() {
   if (fs.existsSync(settingsPath)) {
     try {
       const s = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-      settingsOk = s?.env?.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === '1' && s?.teammateMode === 'tmux';
+      const hasAgentTeams = s?.env?.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === '1';
+      const hasTmux = s?.teammateMode === 'tmux';
+      const hasIdleHook = Array.isArray(s?.hooks?.TeammateIdle) && s.hooks.TeammateIdle.length > 0;
+      settingsOk = hasAgentTeams && hasTmux && hasIdleHook;
     } catch {}
   }
   console.log(`  [${settingsOk ? '✓' : '✗'}] ${SETTINGS_PATH} (agent teams settings)`);

--- a/roles/team-manager.md
+++ b/roles/team-manager.md
@@ -34,7 +34,7 @@ When you first start, do the following:
    context: <any additional context needed>
    ```
 
-3. **React to reports** — Team members report back via direct message when a task is complete or blocked. When a report arrives, decide the next action:
+3. **React to reports** — Team members report back via direct message when a task is complete or blocked. When a report arrives, decide the next action and then **dismiss the reporting team member** — they have no further work to do. (The `TeammateIdle` hook handles this automatically when a teammate goes idle after reporting; you do not need to take any explicit action to stop them.)
    - A triage report comes in with a valid `next_issue` → delegate a planning task for that issue.
    - A triage report comes in with `next_issue: null` → check whether any non-Done issues remain. If all issues are Done, proceed to Shutdown. If blocked issues remain, report to the user that all remaining work is blocked, list each blocked issue and its blocker, and wait for direction before doing anything else.
    - A `plan-report` comes in → route based on `next_task`:


### PR DESCRIPTION
## Summary

- Adds a `TeammateIdle` hook to `REQUIRED_SETTINGS` in `lib/install.js` so the Claude Code harness automatically stops teammates when they go idle after reporting back
- Adds a `mergeHooks` helper to safely deep-merge the `hooks` object on repeated installs, preventing duplicate hook entries
- Updates `status()` to also verify the `TeammateIdle` hook is present in `settings.json`
- Documents the idle-dismissal behavior in `roles/team-manager.md`
- Adds 3 static eval tests in `evals/test_static.py` to guard the invariant

## Root cause

The session logs in issue #4 showed teammates (`@coder`, `@planner`, `@tester`, etc.) remaining idle after completing their tasks and reporting back. The `REQUIRED_SETTINGS` installed by `npx autonomous-product-team init` did not include a `TeammateIdle` hook, so the harness never stopped them.

## How it works

Claude Code fires a `TeammateIdle` event when a teammate goes idle. If a hook for that event returns `{"continue": false}`, the harness stops the teammate. The installed hook runs `echo '{"continue": false}'`, which causes any teammate that goes idle to be stopped automatically — no action required from the team manager.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)