### PR TITLE
Add Claude Code hooks for safety, context, and observability (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ This installs the agent team files into your project:
 - `.claude/skills/team-member/SKILL.md` — executor agent
 - `.claude/product-team/tasks/` — 7 task definitions
 
+This also installs Claude Code hooks into `.claude/hooks/` and registers them in `.claude/settings.json`:
+- **guard-destructive-git.sh** — blocks dangerous git commands (`push --force`, `reset --hard`, `clean -f`, `branch -D`)
+- **guard-worktree-discipline.sh** — prevents agents from writing files in the main checkout when they should be in a worktree
+- **load-session-context.sh** — loads project config on session start so agents do not re-ask for repo/PM details
+- **log-agent-event.sh** — logs subagent lifecycle events to `.claude/product-team/agent.log` for observability
+
 Then open Claude Code in your project and ask:
 > "Use the team-manager skill to start working on my product"
 

--- a/docs/hooks-discovery.md
+++ b/docs/hooks-discovery.md
@@ -1,0 +1,237 @@
+# Claude Code Hooks — Discovery Report
+
+## What are Claude Code Hooks?
+
+Hooks are user-defined shell commands, HTTP endpoints, or LLM prompts that execute automatically at specific points in Claude Code's lifecycle. They enable automation, validation, and control over Claude's actions — without requiring changes to the prompts or task definitions themselves.
+
+### Hook Types
+
+| Type | Description |
+|------|-------------|
+| `command` | Shell command; receives JSON via stdin, returns decision via exit code / stdout |
+| `http` | POST request to a remote endpoint |
+| `prompt` | Sends a yes/no question to a Claude model |
+| `agent` | Spawns a subagent to evaluate a condition (experimental) |
+
+### Hook Events (Lifecycle)
+
+**Session lifecycle:**
+- `SessionStart` — fires on startup, resume, clear, or compact
+- `SessionEnd` — fires when the session terminates
+
+**Turn lifecycle:**
+- `UserPromptSubmit` — fires before Claude processes a prompt; can block or add context
+- `Stop` — fires when Claude finishes a response; can block Claude from stopping
+- `StopFailure` — fires when the stop itself fails
+
+**Tool lifecycle (most powerful):**
+- `PreToolUse` — fires before a tool runs; can allow, deny, modify input, or defer
+- `PostToolUse` — fires after a successful tool call; can add feedback
+- `PostToolUseFailure` — fires after a tool fails
+
+**Other events:**
+- `SubagentStart` / `SubagentStop` — subagent lifecycle
+- `TaskCreated` / `TaskCompleted` — task lifecycle
+- `WorktreeCreate` / `WorktreeRemove` — worktree operations
+- `PermissionRequest` / `PermissionDenied` — permission system integration
+- `FileChanged` — watched file mutations
+- `InstructionsLoaded` — when CLAUDE.md files load
+
+### Configuration
+
+Hooks are defined in `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/validate-bash.sh",
+            "timeout": 10,
+            "statusMessage": "Validating command..."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Hooks can also be defined in skill/task frontmatter (scoped to that skill's lifetime).
+
+---
+
+## How the Current System Works
+
+The autonomous-product-team project installs:
+- `roles/team-manager.md` → `.claude/skills/team-manager/SKILL.md`
+- `roles/team-member.md` → `.claude/skills/team-member/SKILL.md`
+- 8 task definitions → `.claude/product-team/tasks/`
+- `.claude/settings.json` with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` and `teammateMode=tmux`
+
+No hooks are currently configured.
+
+---
+
+## Hook Opportunities for This Project
+
+### 1. Guard Against Destructive Git Operations (HIGH PRIORITY)
+
+**Event:** `PreToolUse` on `Bash`
+
+**Problem:** Agents running `git push --force`, `git reset --hard`, `git clean -f`, or `git checkout .` on the main repo checkout could destroy uncommitted work or corrupt the worktree setup. The task definitions warn against this, but the warning is enforced only at the prompt level.
+
+**Hook:** A shell script that inspects the command and denies any of the following patterns:
+- `git push.*--force` / `git push.*-f`
+- `git reset --hard`
+- `git clean -f` / `git clean -fd`
+- `git checkout --` (discards working tree changes)
+- `git branch -D` (deletes branches)
+
+**Implementation sketch:**
+```bash
+#!/bin/bash
+COMMAND=$(jq -r '.tool_input.command // empty')
+DANGEROUS_PATTERNS=("git push.*--force" "git push.*-f" "git reset --hard" "git clean -f" "git branch -D")
+for pattern in "${DANGEROUS_PATTERNS[@]}"; do
+  if echo "$COMMAND" | grep -qE "$pattern"; then
+    jq -n '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny",
+      permissionDecisionReason: "Destructive git command blocked by autonomous-product-team hook. Run manually if intentional."}}'
+    exit 0
+  fi
+done
+exit 0
+```
+
+**Files to add:**
+- `.claude/hooks/guard-destructive-git.sh` (the hook script)
+- Reference in `.claude/settings.json` and `lib/install.js` MANIFEST
+
+---
+
+### 2. Enforce Worktree Discipline (HIGH PRIORITY)
+
+**Event:** `PreToolUse` on `Edit`, `Write`, `MultiEdit`
+
+**Problem:** Task definitions instruct agents to edit files only inside the worktree, never in the main checkout. But there's no enforcement — a confused agent could edit files in `/Users/alyson/projects/autonomous-product-team/` instead of the worktree. This could corrupt the main branch state.
+
+**Hook:** Check if `$CLAUDE_PROJECT_DIR` is the main checkout. If a write tool targets a file that is under the main checkout directory but the agent is expected to be working in a worktree (detectable by checking if a worktree path is active), deny the call.
+
+**Note:** This requires either (a) a convention-based check on the file path, or (b) reading a small state file written during worktree setup. The simpler approach is option (a): deny writes to the repo root if the path matches the main checkout and the branch is not `main`.
+
+---
+
+### 3. Session Context Loader (MEDIUM PRIORITY)
+
+**Event:** `SessionStart` with matcher `startup` and `resume`
+
+**Problem:** Every time a team-manager or team-member session starts, the agent must discover or be told which GitHub repo and PM system to use. For the team-manager, this means asking the user on every fresh start. For resumed sessions, the context is re-established from memory only.
+
+**Hook:** On session start, read a lightweight project config file (e.g. `.claude/product-team/config.json`) containing the repo, PM system, and project identifier, and inject it as `additionalContext`.
+
+**Implementation sketch:**
+```bash
+#!/bin/bash
+CONFIG_FILE="$CLAUDE_PROJECT_DIR/.claude/product-team/config.json"
+if [ -f "$CONFIG_FILE" ]; then
+  REPO=$(jq -r '.repo // empty' "$CONFIG_FILE")
+  PM=$(jq -r '.pm_system // empty' "$CONFIG_FILE")
+  PROJECT=$(jq -r '.project_id // empty' "$CONFIG_FILE")
+  jq -n --arg ctx "Project config: repo=$REPO, pm_system=$PM, project_id=$PROJECT" \
+    '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
+fi
+exit 0
+```
+
+**Installer change:** `lib/install.js` should prompt for repo + PM system during `init` and write `config.json`. Or the team-manager's first run creates it.
+
+---
+
+### 4. Enforce Structured Reports on Stop (MEDIUM PRIORITY)
+
+**Event:** `Stop`
+
+**Problem:** Team members are supposed to report back with structured YAML messages. If a team member finishes without sending a report (e.g. just says "Done"), the team manager receives no message and the workflow stalls. There's currently no enforcement.
+
+**Hook type:** `prompt` — ask Claude to evaluate whether the session produced a valid structured report before allowing it to stop.
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Did this session end with a structured report message (containing a 'type:' field like 'plan-report', 'task-complete', 'test-report', etc.) sent to 'team-manager'? Answer yes or no.",
+            "model": "claude-haiku-4-5"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Caveat:** This would trigger for team-manager sessions too. Matcher could be scoped, but Stop hooks do not currently support skill-scoped matchers in the same way PreToolUse does.
+
+---
+
+### 5. Subagent Observability Logging (LOW PRIORITY)
+
+**Event:** `SubagentStart`, `SubagentStop`, `TaskCreated`, `TaskCompleted`
+
+**Problem:** When multiple subagents are running (team-manager spawning team-members), there's no structured log of which agent started, what it was doing, and when it finished. Debugging failures requires reading terminal output, which can be interleaved and hard to trace.
+
+**Hook:** A shell command that appends a JSON log entry to `.claude/product-team/agent.log` on each subagent lifecycle event. The hook receives the subagent's task context in the JSON payload.
+
+**Implementation sketch:**
+```bash
+#!/bin/bash
+EVENT=$(jq -r '.hook_event_name // empty')
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+echo "{\"event\": \"$EVENT\", \"timestamp\": \"$TIMESTAMP\", \"payload\": $(cat)}" \
+  >> "$CLAUDE_PROJECT_DIR/.claude/product-team/agent.log"
+exit 0
+```
+
+---
+
+### 6. Installer Integration (REQUIRED FOR ALL HOOKS)
+
+For hooks to be useful in a distributed package, they need to be:
+1. Shipped as files in the package (`hooks/` directory at repo root)
+2. Copied to the target project during `init` (added to the `MANIFEST` in `lib/install.js`)
+3. Registered in `REQUIRED_SETTINGS` in `lib/install.js` so `mergeSettings` writes them into `.claude/settings.json`
+
+The `mergeSettings` function currently only writes `env` and `teammateMode`. It would need to be extended to merge the `hooks` object into the settings, following the same pattern — merging without overwriting user-defined hooks.
+
+---
+
+## Recommended Implementation Order
+
+| Priority | Hook | Event | Benefit |
+|----------|------|-------|---------|
+| 1 | Guard destructive git | `PreToolUse(Bash)` | Safety — prevents irreversible damage |
+| 2 | Worktree discipline | `PreToolUse(Edit\|Write)` | Safety — prevents main checkout corruption |
+| 3 | Session context loader | `SessionStart` | DX — removes repetitive context setup |
+| 4 | Structured report enforcement | `Stop` | Reliability — prevents silent workflow stalls |
+| 5 | Subagent observability | `SubagentStart/Stop` | Debugging — structured log of agent activity |
+
+---
+
+## Files That Would Need to Change
+
+| File | Change |
+|------|--------|
+| `hooks/guard-destructive-git.sh` | New: shell script for hook #1 |
+| `hooks/load-session-context.sh` | New: shell script for hook #3 |
+| `hooks/log-subagent-event.sh` | New: shell script for hook #5 |
+| `lib/install.js` | Update MANIFEST to copy hooks; extend mergeSettings to write hooks config |
+| `.claude/settings.json` (target project) | Written by updated installer |
+| `evals/test_static.py` | Add tests asserting hooks are present in settings and hook scripts exist |

--- a/evals/test_static.py
+++ b/evals/test_static.py
@@ -249,6 +249,45 @@ class TestManagerHandlesAllReports:
         assert "status-correction-report" in content
 
 
+class TestHooksExistence:
+    """Hook scripts must exist on disk and be referenced in the installer."""
+
+    HOOK_SCRIPTS = [
+        "hooks/guard-destructive-git.sh",
+        "hooks/guard-worktree-discipline.sh",
+        "hooks/load-session-context.sh",
+        "hooks/log-agent-event.sh",
+    ]
+
+    def test_all_hook_scripts_exist(self):
+        for script in self.HOOK_SCRIPTS:
+            assert (REPO_ROOT / script).exists(), f"Hook script missing: {script}"
+
+    def test_hook_scripts_are_executable(self):
+        import os
+        for script in self.HOOK_SCRIPTS:
+            filepath = REPO_ROOT / script
+            assert os.access(filepath, os.X_OK), f"Hook script not executable: {script}"
+
+    def test_hooks_in_install_manifest(self):
+        content = load_file("lib/install.js")
+        for script in self.HOOK_SCRIPTS:
+            assert script in content, f"Hook script not in MANIFEST: {script}"
+
+    def test_hooks_config_in_required_settings(self):
+        content = load_file("lib/install.js")
+        assert "'hooks'" in content or '"hooks"' in content or "hooks:" in content, (
+            "REQUIRED_SETTINGS must include a hooks configuration"
+        )
+        # Verify specific hook events are configured
+        for event in ["PreToolUse", "SessionStart", "SubagentStart", "SubagentStop"]:
+            assert event in content, f"REQUIRED_SETTINGS hooks must include {event}"
+
+    def test_hooks_in_package_files(self):
+        content = load_file("package.json")
+        assert "hooks/" in content, "package.json files must include hooks/"
+
+
 class TestModelSpecification:
     """Every task and role must specify a valid model in YAML frontmatter."""
 

--- a/hooks/guard-destructive-git.sh
+++ b/hooks/guard-destructive-git.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Hook: Guard Against Destructive Git Operations
+# Event: PreToolUse on Bash
+# Blocks dangerous git commands that could cause irreversible damage.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+DANGEROUS_PATTERNS=(
+  "git push.*--force"
+  "git push.*-f[^i]"
+  "git reset --hard"
+  "git clean -f"
+  "git checkout -- \."
+  "git checkout \."
+  "git restore \."
+  "git branch -D"
+)
+
+for pattern in "${DANGEROUS_PATTERNS[@]}"; do
+  if echo "$COMMAND" | grep -qE "$pattern"; then
+    jq -n '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: "Destructive git command blocked by autonomous-product-team hook. Run manually if intentional."}}'
+    exit 0
+  fi
+done
+
+exit 0

--- a/hooks/guard-worktree-discipline.sh
+++ b/hooks/guard-worktree-discipline.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Hook: Enforce Worktree Discipline
+# Event: PreToolUse on Edit, Write, MultiEdit
+# Denies writes to files under the main checkout when an agent should be
+# working inside a worktree.
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Only enforce when CLAUDE_PROJECT_DIR is set (the main checkout root)
+if [ -z "$CLAUDE_PROJECT_DIR" ]; then
+  exit 0
+fi
+
+# Get the current git branch
+BRANCH=$(git -C "$CLAUDE_PROJECT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# If we are on main, no worktree discipline needed — we ARE the main checkout
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  exit 0
+fi
+
+# Check if the file path is inside the main checkout (not a worktree)
+REAL_PROJECT_DIR=$(cd "$CLAUDE_PROJECT_DIR" && pwd -P)
+REAL_FILE_DIR=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && pwd -P)
+
+if [ -z "$REAL_FILE_DIR" ]; then
+  exit 0
+fi
+
+# If the file is under the main checkout, deny the write
+if [[ "$REAL_FILE_DIR" == "$REAL_PROJECT_DIR"* ]]; then
+  # Check if this is actually a worktree (worktrees have .git as a file, not a directory)
+  if [ -d "$CLAUDE_PROJECT_DIR/.git" ]; then
+    # This is the main checkout (not a worktree) — deny writes from non-main branches
+    jq -n '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: "Write to main checkout blocked. You should be editing files in the worktree, not the main checkout."}}'
+    exit 0
+  fi
+fi
+
+exit 0

--- a/hooks/load-session-context.sh
+++ b/hooks/load-session-context.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Hook: Session Context Loader
+# Event: SessionStart (matcher: startup, resume)
+# Reads project config and injects it as additional context so
+# agents do not need to re-ask the user for repo/PM details.
+
+CONFIG_FILE="$CLAUDE_PROJECT_DIR/.claude/product-team/config.json"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  exit 0
+fi
+
+REPO=$(jq -r '.repo // empty' "$CONFIG_FILE")
+PM=$(jq -r '.pm_system // empty' "$CONFIG_FILE")
+PROJECT=$(jq -r '.project_id // empty' "$CONFIG_FILE")
+
+if [ -n "$REPO" ] || [ -n "$PM" ] || [ -n "$PROJECT" ]; then
+  CONTEXT="Project config: repo=$REPO, pm_system=$PM, project_id=$PROJECT"
+  jq -n --arg ctx "$CONTEXT" \
+    '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
+fi
+
+exit 0

--- a/hooks/log-agent-event.sh
+++ b/hooks/log-agent-event.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Hook: Subagent Observability Logging
+# Events: SubagentStart, SubagentStop, TaskCreated, TaskCompleted
+# Appends JSON log entries to .claude/product-team/agent.log for tracing.
+
+INPUT=$(cat)
+EVENT=$(echo "$INPUT" | jq -r '.hook_event_name // empty')
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+LOG_DIR="$CLAUDE_PROJECT_DIR/.claude/product-team"
+LOG_FILE="$LOG_DIR/agent.log"
+
+# Ensure the log directory exists
+mkdir -p "$LOG_DIR" 2>/dev/null
+
+# Append the event as a JSON line
+jq -n \
+  --arg event "$EVENT" \
+  --arg timestamp "$TIMESTAMP" \
+  --argjson payload "$INPUT" \
+  '{event: $event, timestamp: $timestamp, payload: $payload}' \
+  >> "$LOG_FILE" 2>/dev/null
+
+exit 0

--- a/lib/install.js
+++ b/lib/install.js
@@ -13,6 +13,10 @@ const MANIFEST = [
   { src: 'tasks/plan.md',                dest: '.claude/product-team/tasks/plan.md' },
   { src: 'tasks/status-correction.md',   dest: '.claude/product-team/tasks/status-correction.md' },
   { src: 'tasks/test.md',                dest: '.claude/product-team/tasks/test.md' },
+  { src: 'hooks/guard-destructive-git.sh',  dest: '.claude/hooks/guard-destructive-git.sh',  mode: 0o755 },
+  { src: 'hooks/guard-worktree-discipline.sh', dest: '.claude/hooks/guard-worktree-discipline.sh', mode: 0o755 },
+  { src: 'hooks/load-session-context.sh',   dest: '.claude/hooks/load-session-context.sh',   mode: 0o755 },
+  { src: 'hooks/log-agent-event.sh',        dest: '.claude/hooks/log-agent-event.sh',        mode: 0o755 },
 ];
 
 function rewriteTaskPaths(content) {
@@ -35,18 +39,90 @@ const REQUIRED_SETTINGS = {
         ],
       },
     ],
+    PreToolUse: [
+      {
+        matcher: 'Bash',
+        hooks: [
+          {
+            type: 'command',
+            command: '.claude/hooks/guard-destructive-git.sh',
+            timeout: 10,
+          },
+        ],
+      },
+      {
+        matcher: 'Edit|Write|MultiEdit',
+        hooks: [
+          {
+            type: 'command',
+            command: '.claude/hooks/guard-worktree-discipline.sh',
+            timeout: 10,
+          },
+        ],
+      },
+    ],
+    SessionStart: [
+      {
+        matcher: 'startup|resume',
+        hooks: [
+          {
+            type: 'command',
+            command: '.claude/hooks/load-session-context.sh',
+            timeout: 10,
+          },
+        ],
+      },
+    ],
+    SubagentStart: [
+      {
+        matcher: '*',
+        hooks: [
+          {
+            type: 'command',
+            command: '.claude/hooks/log-agent-event.sh',
+            timeout: 10,
+          },
+        ],
+      },
+    ],
+    SubagentStop: [
+      {
+        matcher: '*',
+        hooks: [
+          {
+            type: 'command',
+            command: '.claude/hooks/log-agent-event.sh',
+            timeout: 10,
+          },
+        ],
+      },
+    ],
   },
 };
 
-function mergeHooks(existing, required) {
-  if (!existing) return required;
-  const merged = { ...existing };
-  for (const [event, matchers] of Object.entries(required)) {
+function mergeHooks(existingHooks, requiredHooks) {
+  const merged = { ...existingHooks };
+  for (const [event, requiredEntries] of Object.entries(requiredHooks)) {
     if (!merged[event]) {
-      merged[event] = matchers;
+      merged[event] = requiredEntries;
+      continue;
     }
-    // If the event already has entries, leave them as-is to avoid duplicating
-    // the stop hook on repeated installs.
+    // For each required entry, check if a matching entry (same matcher) exists
+    for (const required of requiredEntries) {
+      const existingIdx = merged[event].findIndex(e => e.matcher === required.matcher);
+      if (existingIdx === -1) {
+        merged[event].push(required);
+      } else {
+        // Merge hooks arrays, avoiding duplicates by command
+        const existingEntry = merged[event][existingIdx];
+        for (const hook of required.hooks) {
+          const hasDuplicate = existingEntry.hooks.some(h => h.command === hook.command);
+          if (!hasDuplicate) {
+            existingEntry.hooks.push(hook);
+          }
+        }
+      }
+    }
   }
   return merged;
 }
@@ -57,12 +133,16 @@ function mergeSettings(projectRoot, dryRun) {
     ? JSON.parse(fs.readFileSync(settingsPath, 'utf8'))
     : {};
 
+  const { hooks: requiredHooks, ...requiredRest } = REQUIRED_SETTINGS;
   const merged = {
     ...existing,
-    ...REQUIRED_SETTINGS,
-    env: { ...existing.env, ...REQUIRED_SETTINGS.env },
-    hooks: mergeHooks(existing.hooks, REQUIRED_SETTINGS.hooks),
+    ...requiredRest,
+    env: { ...existing.env, ...requiredRest.env },
   };
+
+  if (requiredHooks) {
+    merged.hooks = mergeHooks(existing.hooks || {}, requiredHooks);
+  }
 
   const action = fs.existsSync(settingsPath) ? 'updated' : 'installed';
   if (!dryRun) {
@@ -122,6 +202,7 @@ async function run({ force = false, dryRun = false } = {}) {
     let content = fs.readFileSync(srcPath, 'utf8');
     if (entry.transform) content = entry.transform(content);
     fs.writeFileSync(destPath, content);
+    if (entry.mode) fs.chmodSync(destPath, entry.mode);
     results.push({ dest: entry.dest, action: exists ? 'updated' : 'installed' });
   }
 
@@ -155,6 +236,7 @@ function status() {
 
   const settingsPath = path.join(projectRoot, SETTINGS_PATH);
   let settingsOk = false;
+  let hooksOk = false;
   if (fs.existsSync(settingsPath)) {
     try {
       const s = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
@@ -162,9 +244,11 @@ function status() {
       const hasTmux = s?.teammateMode === 'tmux';
       const hasIdleHook = Array.isArray(s?.hooks?.TeammateIdle) && s.hooks.TeammateIdle.length > 0;
       settingsOk = hasAgentTeams && hasTmux && hasIdleHook;
+      hooksOk = !!(s?.hooks?.PreToolUse && s?.hooks?.SessionStart);
     } catch {}
   }
   console.log(`  [${settingsOk ? '✓' : '✗'}] ${SETTINGS_PATH} (agent teams settings)`);
+  console.log(`  [${hooksOk ? '✓' : '✗'}] ${SETTINGS_PATH} (hooks configuration)`);
   console.log('');
 }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "files": [
     "bin/",
+    "hooks/",
     "lib/",
     "roles/",
     "tasks/",


### PR DESCRIPTION
## Summary

- Add four Claude Code hooks that fire at lifecycle events to enforce safety, load context, and provide observability
- **guard-destructive-git.sh** (PreToolUse/Bash): blocks dangerous git commands like `push --force`, `reset --hard`, `clean -f`, `branch -D`
- **guard-worktree-discipline.sh** (PreToolUse/Edit|Write|MultiEdit): prevents agents from writing to the main checkout when they should be in a worktree
- **load-session-context.sh** (SessionStart): injects project config so agents do not re-ask for repo/PM details
- **log-agent-event.sh** (SubagentStart/Stop): logs agent lifecycle events to `.claude/product-team/agent.log`
- Update `lib/install.js` to copy hooks, preserve executable permissions, register all hooks in settings.json with deep-merge logic
- Add 5 static tests verifying hooks exist, are executable, and are wired into the installer
- Update README.md with hooks documentation

Closes #6

## Test plan

- [x] All 47 static tests pass (`evals/test_static.py`)
- [x] Branch rebased on latest main (resolved conflict with TeammateIdle hook)
- [x] Hook scripts are executable
- [x] Hooks config merges cleanly with existing settings (TeammateIdle preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)