### PR TITLE
Add text-inferred and semantic dependency detection to issue triage (#9)

### DIFF
--- a/evals/test_triage.py
+++ b/evals/test_triage.py
@@ -134,6 +134,54 @@ No issue data was returned.""",
         ],
     },
     {
+        "name": "explicit_body_reference_blocks",
+        "description": "Issue body contains 'Depends on #B' where B is not Done — A must be Blocked",
+        "mock_context": """\
+PM system returned 2 non-Done issues:
+
+- PROJ-601 "Build onboarding flow" — Status: Todo — Priority: High
+  Dependencies (PM system links): none
+  Issue body: "This work depends on #602 being completed first. We need the user auth \
+system before we can build onboarding."
+
+- PROJ-602 "Implement user auth system" — Status: Todo — Priority: High
+  Dependencies (PM system links): none
+  Issue body: "Set up authentication with OAuth2 and JWT tokens."
+
+PROJ-602 has no dependencies and no unresolved decisions.
+PROJ-601 has no formal PM-system dependency links, but its body text says "depends on #602".""",
+        "rubric": [
+            "report type is 'triage-report'",
+            "next_issue is PROJ-602 (PROJ-601 is blocked by its body reference to #602 which is not Done, so PROJ-602 is the only ready issue)",
+            "PROJ-601 is NOT selected as next_issue (it is blocked because its body says 'depends on #602' and #602 is not Done)",
+        ],
+    },
+    {
+        "name": "semantic_dependency_blocks",
+        "description": "One issue describes running a capability another issue creates — the 'run' issue is Blocked, the 'create' issue is Ready",
+        "mock_context": """\
+PM system returned 2 non-Done issues:
+
+- PROJ-701 "Run a discovery on claude code hooks" — Status: Todo — Priority: Medium
+  Dependencies (PM system links): none
+  Issue body: "Run a product discovery to explore how teams use claude code hooks. \
+Interview users, gather data, and synthesize findings."
+
+- PROJ-702 "Create a discovery task type" — Status: Todo — Priority: Medium
+  Dependencies (PM system links): none
+  Issue body: "Add a new 'discovery' task type to our product development process. \
+Define the template, inputs, outputs, and workflow for running discoveries."
+
+Neither issue has formal PM-system dependency links. No unresolved decisions exist.
+Note: PROJ-701 describes *running* a discovery, which requires the discovery task type \
+that PROJ-702 would create. There are no explicit cross-references between them.""",
+        "rubric": [
+            "report type is 'triage-report'",
+            "next_issue is PROJ-702 (it creates the capability that PROJ-701 needs, making it the ready issue)",
+            "PROJ-701 is NOT selected as next_issue (it semantically depends on the discovery task type that PROJ-702 will create)",
+        ],
+    },
+    {
         "name": "implementation_difficulty_is_not_a_blocker",
         "description": "Hard issue with no external blockers must be classified Ready, not Blocked",
         "mock_context": """\

--- a/tasks/issue-triage.md
+++ b/tasks/issue-triage.md
@@ -25,13 +25,21 @@ An issue is **not** blocked solely because its implementation is difficult or un
 
 1. **Fetch all issues** — Query the product development management system for every issue in the project that is not Done. Fetch issues with basic fields first (id, title, status, priority). Then check each issue's dependencies individually with a separate lookup per issue — do not attempt to fetch all issues and all their relations in a single query.
 
-2. **Check blockers** — For each issue, check its dependencies. An issue is blocked if any dependency is not Done. An issue is also blocked if it requires an unresolved product or architectural decision.
+2. **Check blockers** — For each issue, determine whether it is blocked using all of the following methods:
+
+   a. **Formal dependencies** — Check the PM system's dependency links. An issue is blocked if any linked dependency is not Done.
+
+   b. **Text-inferred dependencies** — Scan each issue's body for cross-reference patterns such as "Depends on #N", "Blocked by #N", "Requires #N", "After #N", or any mention of another issue as a prerequisite. When found, check whether referenced issue #N is Done; if not, the current issue is Blocked.
+
+   c. **Semantic dependencies** — Reason about what each issue describes. If issue A describes *running, using, or exercising* a capability, and issue B describes *creating, building, or implementing* that same capability, then A depends on B. If B is not Done, classify A as Blocked by B.
+
+   d. **Unresolved decisions** — An issue is also blocked if it requires an unresolved product or architectural decision.
 
 3. **Classify each issue** as one of:
    - **Ready** — All dependencies are Done (or no dependencies). Can be assigned immediately.
    - **Blocked** — One or more dependencies are not Done, or an external decision is pending. Note what is blocking it.
 
-4. **Rank ready issues** — Sort the ready issues by priority (highest first), using the priority assigned in the product development management system. If priorities are equal, prefer the issue with the earliest creation date.
+4. **Rank ready issues** — Sort the ready issues by priority (highest first), using the priority assigned in the product development management system. If priorities are equal, prefer the issue with the earliest creation date. Note: formal PM-system dependency links, text-inferred cross-references, and semantic dependencies all count equally when determining whether an issue is Blocked or Ready.
 
 5. **Report** — Use the `message` tool to message `team-manager` using this schema:
 


### PR DESCRIPTION
## Summary
- Updates `tasks/issue-triage.md` Step 2 to detect dependencies via three methods: formal PM-system links, text-inferred cross-references (e.g. "Depends on #N"), and semantic reasoning (e.g. "run a discovery" depends on "create a discovery task type")
- Updates Step 4 to clarify that all dependency types count equally when determining Blocked vs Ready
- Adds two new eval scenarios (`explicit_body_reference_blocks` and `semantic_dependency_blocks`) to `evals/test_triage.py` validating the new dependency detection

## Test plan
- [x] All 39 static tests pass (`evals/test_static.py`)
- [x] All 9 triage eval tests pass (`evals/test_triage.py`), including the 2 new scenarios
- [x] Branch rebased on latest main

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)