### PR TITLE
Add discovery task for exploring issues and creating follow-up work (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npx @alysonbasilio/autonomous-product-team init
 This installs the agent team files into your project:
 - `.claude/skills/team-manager/SKILL.md` — orchestration agent
 - `.claude/skills/team-member/SKILL.md` — executor agent
-- `.claude/product-team/tasks/` — 7 task definitions
+- `.claude/product-team/tasks/` — 8 task definitions
 
 This also installs Claude Code hooks into `.claude/hooks/` and registers them in `.claude/settings.json`:
 - **guard-destructive-git.sh** — blocks dangerous git commands (`push --force`, `reset --hard`, `clean -f`, `branch -D`)

--- a/evals/test_discovery.py
+++ b/evals/test_discovery.py
@@ -1,0 +1,149 @@
+"""
+LLM-as-judge evals for the Discovery task.
+
+Each scenario simulates a discovery context and verifies that the discovery
+agent produces correct follow-up issues and a valid discovery-complete report.
+
+Requires OPENROUTER_API_KEY.
+"""
+import pytest
+
+from conftest import load_task, parse_frontmatter_model
+from judge import grade
+
+TASK_FILE = "tasks/discovery.md"
+TASK_MODEL = parse_frontmatter_model(TASK_FILE)
+
+EVAL_PROMPT = """\
+You are a team member executing a task. Read the task definition carefully and follow it.
+
+## Task Definition
+{task_content}
+
+## Simulated Environment
+
+The following data represents what you would receive from calling the PM system and codebase tools. \
+Treat this as the actual result of your tool calls — do not request additional information.
+
+{mock_context}
+
+Produce the complete output report as defined in the task. Output ONLY the report — no preamble, no explanation.
+"""
+
+SCENARIOS = [
+    {
+        "name": "basic_discovery_creates_issues",
+        "description": "Given a vague feature request, agent creates appropriately scoped follow-up issues",
+        "mock_context": """\
+PM system issue:
+- ID: PROJ-50
+- Title: "We should have a notification system"
+- Description: "Users have asked for notifications so they know when important things happen in their account. \
+We need to figure out what this looks like and break it into concrete work."
+- Status: Backlog
+- Comments: none
+
+Codebase research results:
+- No existing notification code found in the codebase
+- The app has a User model with email and phone fields (src/models/user.py)
+- There is an existing event system that logs user actions (src/events/logger.py)
+- The frontend uses React with a top-level App component (src/frontend/App.tsx)
+- No WebSocket infrastructure exists currently
+
+Existing non-Done issues in PM system:
+- PROJ-45 "Add user preferences page" — Status: Todo — no dependencies
+- PROJ-48 "Improve email delivery reliability" — Status: In Progress — no dependencies
+
+PM system created the following issues when requested:
+- PROJ-51 "Define notification types and delivery channels" — Status: Backlog, Priority: No priority
+- PROJ-52 "Build notification service backend" — Status: Backlog, Priority: No priority
+- PROJ-53 "Add in-app notification UI" — Status: Backlog, Priority: No priority""",
+        "rubric": [
+            "report type is 'discovery-complete'",
+            "at least two follow-up issues are created (the discovery breaks the vague request into concrete work)",
+            "follow-up issue descriptions include background referencing the discovery issue PROJ-50",
+            "follow-up issues are scoped to specific pieces of work, not just restating the original request",
+        ],
+    },
+    {
+        "name": "discovery_with_existing_codebase_context",
+        "description": "Agent reads relevant files and uses that context in issue descriptions",
+        "mock_context": """\
+PM system issue:
+- ID: PROJ-60
+- Title: "Support bulk CSV import for products"
+- Description: "Merchants want to upload a CSV file to create or update many products at once \
+instead of entering them one by one."
+- Status: Backlog
+- Comments: none
+
+Codebase research results:
+- Products are managed via src/api/products.py with a POST /products endpoint for single creation
+- Product model is defined in src/models/product.py with fields: id, name, sku, price, description, merchant_id
+- There is an existing file upload utility at src/utils/upload.py that handles S3 uploads
+- The API uses FastAPI with Pydantic validation (src/api/main.py)
+- Background job processing uses Celery with Redis broker (src/jobs/worker.py)
+- No CSV parsing library is currently in requirements.txt
+
+Existing non-Done issues in PM system:
+- PROJ-55 "Add product image gallery" — Status: Todo — no dependencies
+- PROJ-58 "Rate limit API endpoints" — Status: In Progress — no dependencies
+
+PM system created the following issues when requested:
+- PROJ-61 "Add CSV parsing and validation for product import" — Status: Backlog, Priority: No priority
+- PROJ-62 "Create background job for bulk product import processing" — Status: Backlog, Priority: No priority
+- PROJ-63 "Add CSV import API endpoint and UI upload flow" — Status: Backlog, Priority: No priority""",
+        "rubric": [
+            "report type is 'discovery-complete'",
+            "follow-up issue descriptions reference specific codebase findings (e.g. existing Product model, FastAPI, Celery, or file paths)",
+            "the agent uses codebase context to inform the work breakdown (not just generic implementation steps)",
+            "created issues mention relevant existing infrastructure (e.g. Celery for background jobs, existing upload utility, or Pydantic validation)",
+        ],
+    },
+    {
+        "name": "discovery_produces_discovery_complete_report",
+        "description": "Output schema is correct: type, issue_id, summary, created_issues with id and title",
+        "mock_context": """\
+PM system issue:
+- ID: PROJ-70
+- Title: "Investigate adding dark mode"
+- Description: "Some users have requested dark mode support. We need to understand what this involves."
+- Status: Backlog
+- Comments: none
+
+Codebase research results:
+- Frontend uses Tailwind CSS (tailwind.config.js)
+- No dark mode classes or theme switching logic exists
+- Color values are hardcoded in several component files
+
+Existing non-Done issues in PM system: none
+
+PM system created the following issues when requested:
+- PROJ-71 "Add Tailwind dark mode configuration and theme toggle component" — Status: Backlog, Priority: No priority
+- PROJ-72 "Audit and update hardcoded colors to support dark mode" — Status: Backlog, Priority: No priority""",
+        "rubric": [
+            "report type field is exactly 'discovery-complete'",
+            "issue_id field is present and equals PROJ-70",
+            "summary field is present and is a single sentence describing the discovery",
+            "created_issues field is a list with at least one entry, each having id and title fields",
+        ],
+    },
+]
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=[s["name"] for s in SCENARIOS])
+def test_discovery_scenario(client, scenario):
+    task_content = load_task(TASK_FILE)
+    prompt = EVAL_PROMPT.format(
+        task_content=task_content,
+        mock_context=scenario["mock_context"],
+    )
+    response = client.chat.completions.create(
+        model=TASK_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0,
+        max_tokens=1024,
+    )
+    agent_output = response.choices[0].message.content
+    result = grade(client, scenario, agent_output, task_content)
+    assert result.passed, "\n".join(result.failure_reasons)

--- a/evals/test_manager_routing.py
+++ b/evals/test_manager_routing.py
@@ -268,6 +268,45 @@ Note: The demo reviewer has already merged the PR and marked the issue Done.""",
         ],
     ),
     build_scenario(
+        name="discovery_complete_retriggers_triage",
+        description="discovery-complete report arrives → manager re-triages",
+        message="""\
+type: discovery-complete
+issue_id: PROJ-1301
+summary: Explored notification system requirements and broke them into concrete implementation tasks.
+created_issues:
+  - id: PROJ-1302
+    title: Define notification types and delivery channels
+  - id: PROJ-1303
+    title: Build notification service backend""",
+        rubric=[
+            "re-delegates issue triage (tasks/issue-triage.md)",
+            "does NOT skip triage and start on a specific next issue without re-triaging first",
+            "delegates tasks/create-issue.md since created_issues is present",
+        ],
+    ),
+    build_scenario(
+        name="discovery_complete_with_issues_delegates_create_issue_and_retriage",
+        description="discovery-complete with created_issues → delegate create-issue and re-triage",
+        message="""\
+type: discovery-complete
+issue_id: PROJ-1401
+summary: Investigated bulk CSV import feature and identified three pieces of follow-up work.
+created_issues:
+  - id: PROJ-1402
+    title: Add CSV parsing and validation for product import
+  - id: PROJ-1403
+    title: Create background job for bulk product import processing
+  - id: PROJ-1404
+    title: Add CSV import API endpoint and UI upload flow""",
+        rubric=[
+            "delegates tasks/create-issue.md with the created issues",
+            "re-delegates issue triage (tasks/issue-triage.md)",
+            "delegates BOTH tasks (create-issue and triage) — does not skip either",
+            "does NOT attempt to implement any of the created issues directly",
+        ],
+    ),
+    build_scenario(
         name="blocked_report_escalates_product_decision_to_user",
         description="blocked report requiring product decision → escalate to user, do not resolve unilaterally",
         message="""\

--- a/evals/test_manager_routing.py
+++ b/evals/test_manager_routing.py
@@ -62,6 +62,22 @@ next_issue:
         ],
     ),
     build_scenario(
+        name="triage_discovery_issue_delegates_discovery",
+        description="triage-report with discovery-type issue → delegate discovery task, not plan",
+        message="""\
+type: triage-report
+next_issue:
+  id: PROJ-250
+  title: Investigate notification system requirements
+  summary: Exploratory issue to research what a notification system should look like and break it into concrete work.
+  issue_type: discovery""",
+        rubric=[
+            "delegates tasks/discovery.md (discovery task) for issue PROJ-250",
+            "task-assignment includes issue_id PROJ-250",
+            "does NOT delegate tasks/plan.md or tasks/code.md (this is a discovery issue, not an implementation issue)",
+        ],
+    ),
+    build_scenario(
         name="triage_null_issues_remain_escalates_to_user",
         description="triage-report null + blocked issues remain → escalate to user, do not delegate",
         message="""\
@@ -269,7 +285,7 @@ Note: The demo reviewer has already merged the PR and marked the issue Done.""",
     ),
     build_scenario(
         name="discovery_complete_retriggers_triage",
-        description="discovery-complete report arrives → manager re-triages",
+        description="discovery-complete report arrives → manager re-triages (issues already created by discovery)",
         message="""\
 type: discovery-complete
 issue_id: PROJ-1301
@@ -282,12 +298,12 @@ created_issues:
         rubric=[
             "re-delegates issue triage (tasks/issue-triage.md)",
             "does NOT skip triage and start on a specific next issue without re-triaging first",
-            "delegates tasks/create-issue.md since created_issues is present",
+            "does NOT delegate tasks/create-issue.md (issues were already created by the discovery task itself)",
         ],
     ),
     build_scenario(
-        name="discovery_complete_with_issues_delegates_create_issue_and_retriage",
-        description="discovery-complete with created_issues → delegate create-issue and re-triage",
+        name="discovery_complete_with_issues_no_create_issue",
+        description="discovery-complete with created_issues → re-triage only, no create-issue (discovery already created them)",
         message="""\
 type: discovery-complete
 issue_id: PROJ-1401
@@ -300,9 +316,8 @@ created_issues:
   - id: PROJ-1404
     title: Add CSV import API endpoint and UI upload flow""",
         rubric=[
-            "delegates tasks/create-issue.md with the created issues",
             "re-delegates issue triage (tasks/issue-triage.md)",
-            "delegates BOTH tasks (create-issue and triage) — does not skip either",
+            "does NOT delegate tasks/create-issue.md (the discovery task already created the issues in the PM system)",
             "does NOT attempt to implement any of the created issues directly",
         ],
     ),

--- a/lib/install.js
+++ b/lib/install.js
@@ -11,6 +11,7 @@ const MANIFEST = [
   { src: 'tasks/code.md',                dest: '.claude/product-team/tasks/code.md' },
   { src: 'tasks/issue-triage.md',        dest: '.claude/product-team/tasks/issue-triage.md' },
   { src: 'tasks/plan.md',                dest: '.claude/product-team/tasks/plan.md' },
+  { src: 'tasks/create-issue.md',          dest: '.claude/product-team/tasks/create-issue.md' },
   { src: 'tasks/discovery.md',            dest: '.claude/product-team/tasks/discovery.md' },
   { src: 'tasks/status-correction.md',   dest: '.claude/product-team/tasks/status-correction.md' },
   { src: 'tasks/test.md',                dest: '.claude/product-team/tasks/test.md' },

--- a/lib/install.js
+++ b/lib/install.js
@@ -11,6 +11,7 @@ const MANIFEST = [
   { src: 'tasks/code.md',                dest: '.claude/product-team/tasks/code.md' },
   { src: 'tasks/issue-triage.md',        dest: '.claude/product-team/tasks/issue-triage.md' },
   { src: 'tasks/plan.md',                dest: '.claude/product-team/tasks/plan.md' },
+  { src: 'tasks/discovery.md',            dest: '.claude/product-team/tasks/discovery.md' },
   { src: 'tasks/status-correction.md',   dest: '.claude/product-team/tasks/status-correction.md' },
   { src: 'tasks/test.md',                dest: '.claude/product-team/tasks/test.md' },
   { src: 'hooks/guard-destructive-git.sh',  dest: '.claude/hooks/guard-destructive-git.sh',  mode: 0o755 },

--- a/roles/team-manager.md
+++ b/roles/team-manager.md
@@ -35,7 +35,8 @@ When you first start, do the following:
    ```
 
 3. **React to reports** — Team members report back via direct message when a task is complete or blocked. When a report arrives, decide the next action and then **dismiss the reporting team member** — they have no further work to do. (The `TeammateIdle` hook handles this automatically when a teammate goes idle after reporting; you do not need to take any explicit action to stop them.)
-   - A triage report comes in with a valid `next_issue` → delegate a planning task for that issue.
+   - A triage report comes in with a valid `next_issue` and `issue_type: discovery` → delegate a discovery task (`tasks/discovery.md`) for that issue instead of planning.
+   - A triage report comes in with a valid `next_issue` (with `issue_type: implementation` or no `issue_type`) → delegate a planning task for that issue.
    - A triage report comes in with `next_issue: null` → check whether any non-Done issues remain. If all issues are Done, proceed to Shutdown. If blocked issues remain, report to the user that all remaining work is blocked, list each blocked issue and its blocker, and wait for direction before doing anything else.
    - A `plan-report` comes in → route based on `next_task`:
      - `code` → delegate implementation, passing `branch`, `worktree`, `plan`, and `findings` (if present).
@@ -45,7 +46,7 @@ When you first start, do the following:
      - If `follow_up_issues` is present → delegate a `create-issue` task AND a test task **in parallel**, passing `source_issue_id` and `issues` to the former and `issue_id` and `pr_url` to the latter.
      - If `follow_up_issues` is absent → delegate a test task, passing the `issue_id` and `pr_url`.
    - A `create-issue-complete` arrives → no further action needed (the test task was already delegated in parallel).
-   - A `discovery-complete` arrives → if `created_issues` is present, delegate a `create-issue` task (passing `source_issue_id` as the discovery issue's `issue_id` and `issues` from `created_issues`). Then re-delegate issue triage (`tasks/issue-triage.md`).
+   - A `discovery-complete` arrives → the discovery task has already created all follow-up issues in the PM system. Do NOT delegate a `create-issue` task (the issues already exist). Re-delegate issue triage (`tasks/issue-triage.md`) to pick up the newly created issues.
    - A `task-failed` with `task: tasks/issue-triage.md` arrives → escalate to the user with the exact `failure` details and ask how to proceed. Do not delegate any further work until the user responds.
    - A `task-failed` arrives → mark the issue as Blocked in the product development management system. Escalate to the user with the `issue_id`, the exact `failure` details, and a specific question about what decision or change is needed to unblock it. Do not delegate any further work on this issue until the user responds.
    - A `test-report` arrives:

--- a/roles/team-manager.md
+++ b/roles/team-manager.md
@@ -45,6 +45,7 @@ When you first start, do the following:
      - If `follow_up_issues` is present → delegate a `create-issue` task AND a test task **in parallel**, passing `source_issue_id` and `issues` to the former and `issue_id` and `pr_url` to the latter.
      - If `follow_up_issues` is absent → delegate a test task, passing the `issue_id` and `pr_url`.
    - A `create-issue-complete` arrives → no further action needed (the test task was already delegated in parallel).
+   - A `discovery-complete` arrives → if `created_issues` is present, delegate a `create-issue` task (passing `source_issue_id` as the discovery issue's `issue_id` and `issues` from `created_issues`). Then re-delegate issue triage (`tasks/issue-triage.md`).
    - A `task-failed` with `task: tasks/issue-triage.md` arrives → escalate to the user with the exact `failure` details and ask how to proceed. Do not delegate any further work until the user responds.
    - A `task-failed` arrives → mark the issue as Blocked in the product development management system. Escalate to the user with the `issue_id`, the exact `failure` details, and a specific question about what decision or change is needed to unblock it. Do not delegate any further work on this issue until the user responds.
    - A `test-report` arrives:
@@ -87,3 +88,4 @@ When you first start, do the following:
 | Demo Review | `tasks/demo-review.md` | After every test task passes |
 | Status Correction | `tasks/status-correction.md` | When an issue status is inconsistent with ground truth |
 | Create Issue | `tasks/create-issue.md` | When any task reports `follow_up_issues` |
+| Discovery | `tasks/discovery.md` | When triage returns a discovery-type issue that needs exploration before implementation can begin |

--- a/tasks/discovery.md
+++ b/tasks/discovery.md
@@ -1,0 +1,83 @@
+---
+model: claude-sonnet-4-6
+---
+
+# Task: Discovery
+
+## Input
+
+The team manager provides:
+- `issue_id` — the issue to explore
+
+## Workflow
+
+### 1. Fetch the issue
+
+Retrieve the issue from the product development management system. Read its title, description, and any comments to understand the request, idea, bug, or feature to explore.
+
+### 2. Research
+
+Investigate the codebase and project context:
+- Read relevant source files, configuration, and documentation
+- Search for related patterns, naming conventions, and existing abstractions
+- Check existing issues in the product development management system for related or overlapping work
+
+### 3. Analyze and synthesize
+
+Based on your research, identify:
+- **Unknowns** — what information is still missing or ambiguous
+- **Risks** — technical, product, or integration risks
+- **Open questions** — decisions that need to be made before or during implementation
+- **Concrete work needed** — the specific pieces of implementation, testing, or documentation work required
+
+### 4. Define follow-up issues
+
+For each piece of work identified in step 3, draft a follow-up issue with:
+- **Title** — concise, action-oriented
+- **Description** containing:
+  - **Background** — why this work exists, referencing the discovery issue (`<issue_id>`) and what was learned
+  - **What needs to be done** — concrete description of the work, written so a future implementer can understand it without reading the discovery issue
+  - **Acceptance criteria** — specific, verifiable conditions that define Done
+
+### 5. Create follow-up issues
+
+Create each follow-up issue in the product development management system with:
+- Status: **Backlog**
+- Priority: **No priority**
+
+### 6. Check dependencies
+
+After creating all issues, review the full list of non-Done issues in the product development management system.
+
+For each newly created issue, check:
+- Does it **block** any existing issue?
+- Is it **blocked by** any existing issue?
+- Are there dependencies **between** the newly created issues themselves?
+
+Link any clear dependencies using the product development management system's dependency feature. Do not add speculative links.
+
+### 7. Report
+
+Post a comment to the PM issue using the product development management system tool:
+
+```
+type: discovery-complete
+issue_id: <issue ID>
+summary: <one sentence describing what was explored>
+created_issues:
+  - id: <new issue ID>
+    title: <title>
+```
+
+Then report to `team-manager` with the same content.
+
+## Definition of Done
+
+All follow-up issues have been created, any clear dependencies have been linked, and the discovery-complete report has been delivered to the team manager.
+
+## Rules
+
+- Do not implement anything — this task is exploration and issue creation only.
+- Do not modify the source issue's status, priority, or any other fields — only add a comment.
+- Write issue descriptions for a future implementer who has zero context.
+- Do not invent requirements beyond what the research supports.

--- a/tasks/issue-triage.md
+++ b/tasks/issue-triage.md
@@ -39,16 +39,22 @@ An issue is **not** blocked solely because its implementation is difficult or un
    - **Ready** — All dependencies are Done (or no dependencies). Can be assigned immediately.
    - **Blocked** — One or more dependencies are not Done, or an external decision is pending. Note what is blocking it.
 
+   For each Ready issue, also determine its **issue type**:
+   - `discovery` — The issue is exploratory in nature: it has no concrete implementation acceptance criteria, asks for research, investigation, or breakdown of a vague idea into actionable work.
+   - `implementation` — The issue has concrete acceptance criteria and can proceed directly to planning and coding. This is the default.
+
 4. **Rank ready issues** — Sort the ready issues by priority (highest first), using the priority assigned in the product development management system. If priorities are equal, prefer the issue with the earliest creation date. Note: formal PM-system dependency links, text-inferred cross-references, and semantic dependencies all count equally when determining whether an issue is Blocked or Ready.
 
 5. **Report** — Use the `message` tool to message `team-manager` using this schema:
 
    ```
    type: triage-report
-   next_issue: { id, title, summary }
+   next_issue: { id, title, summary, issue_type }
    ```
 
    `next_issue` is the highest-priority ready issue — the one the team should work on next. If no issues are ready, `next_issue` is null.
+
+   `issue_type` is `discovery` when the issue is exploratory (no concrete acceptance criteria), or `implementation` (the default) when the issue has concrete acceptance criteria and can proceed to planning.
 
    If the product development management system returns an error at any step, stop and use the `message` tool to message `team-manager`:
 


### PR DESCRIPTION
## Summary
- Adds `tasks/discovery.md` — a new task type for exploring a request/idea/bug/feature and creating scoped follow-up issues
- Updates team-manager skill to route `discovery-complete` reports (re-triage, optionally delegate create-issue)
- Adds `evals/test_discovery.py` with 3 LLM-eval scenarios
- Adds 2 new routing scenarios to `evals/test_manager_routing.py`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)