### PR TITLE
Detect and handle merge conflicts (#12)

### DIFF
--- a/evals/test_plan_routing.py
+++ b/evals/test_plan_routing.py
@@ -320,6 +320,28 @@ Unresolved review threads (2):
             "does NOT route to test or demo-review",
         ],
     },
+    # task-complete, PR open, merge conflicts → code to rebase and resolve
+    {
+        "name": "task_complete_pr_has_merge_conflicts",
+        "description": "task-complete + PR open + merge conflicts → code to rebase and resolve conflicts",
+        "mock_context": """\
+Issue: PROJ-115 "Add audit log export"
+Status: In Progress
+Last updated: 2026-04-15 09:00 UTC
+
+PM issue comments (most recent of each type):
+- type: task-complete, task: tasks/code.md, pr_url: https://github.com/org/repo/pull/92 (2026-04-16 10:00 UTC)
+No test-complete comment. No demo-review-complete comment.
+
+Git state: branch feature/PROJ-115-audit-log-export exists. PR #92: OPEN.
+PR mergeability check: mergeable=CONFLICTING, mergeStateStatus=DIRTY — the branch has merge conflicts with main.""",
+        "rubric": [
+            "report type is 'plan-report'",
+            "next_task is 'code'",
+            "findings field mentions merge conflicts or the need to rebase",
+            "does NOT route to test or demo-review while conflicts exist",
+        ],
+    },
     # Row 10: no task-complete, no branch, no PR → fresh implementation
     {
         "name": "no_work_done_start_fresh",

--- a/evals/test_static.py
+++ b/evals/test_static.py
@@ -122,6 +122,49 @@ class TestPlanRoutingTable:
         for value in ["code", "test", "demo-review"]:
             assert value in content, f"plan.md must document next_task value: {value}"
 
+    def test_routing_covers_merge_conflicts(self):
+        content = load_file("tasks/plan.md")
+        assert re.search(r"merge.conflict", content, re.IGNORECASE), (
+            "Plan routing table must handle the case where a PR has merge conflicts"
+        )
+
+    def test_plan_checks_mergeability(self):
+        content = load_file("tasks/plan.md")
+        assert "mergeable" in content.lower(), (
+            "plan.md must instruct the agent to check PR mergeability (e.g. via gh pr view --json mergeable)"
+        )
+
+
+class TestMergeConflictHandling:
+    """Merge conflict detection and resolution must be covered end-to-end."""
+
+    def test_code_instructs_conflict_resolution_on_rebase(self):
+        content = load_file("tasks/code.md")
+        assert re.search(r"conflict", content, re.IGNORECASE), (
+            "code.md must instruct the agent to resolve merge conflicts during rebase"
+        )
+
+    def test_code_instructs_task_failed_on_unresolvable_conflicts(self):
+        content = load_file("tasks/code.md")
+        assert "task-failed" in content, (
+            "code.md must instruct the agent to report task-failed when conflicts cannot be resolved"
+        )
+        assert re.search(r"conflict", content, re.IGNORECASE), (
+            "code.md must mention conflicts in the context of task-failed reporting"
+        )
+
+    def test_demo_review_checks_mergeability_before_merge(self):
+        content = load_file("tasks/demo-review.md")
+        assert "mergeable" in content.lower(), (
+            "demo-review.md must check PR mergeability before attempting to merge"
+        )
+
+    def test_demo_review_blocks_merge_on_conflict(self):
+        content = load_file("tasks/demo-review.md")
+        assert re.search(r"CONFLICTING|conflict", content, re.IGNORECASE), (
+            "demo-review.md must explicitly block merge when the PR has merge conflicts"
+        )
+
 
 class TestInputOutputChain:
     """

--- a/tasks/code.md
+++ b/tasks/code.md
@@ -47,11 +47,15 @@ Ensure the PR is reviewed (automated and/or human). For every review comment:
    ```
    This must return `0` before proceeding.
 
-### 6. Rebase from main and verify before merge
+### 6. Rebase from main and resolve conflicts before merge
 Before merging, rebase your branch onto the latest main to catch integration issues early:
 ```bash
 git fetch origin main && git rebase origin/main
 ```
+If the rebase encounters merge conflicts, resolve each conflict manually, then stage the resolved files and continue the rebase (`git add <file> && git rebase --continue`). After resolving all conflicts, push the updated branch with `git push --force-with-lease`.
+
+If conflicts cannot be resolved (e.g. the conflicting change is incompatible with the issue's requirements and the correct resolution is unclear), report `task-failed` immediately — do not guess at a resolution or push a branch with unresolved conflict markers.
+
 Then run the full test suite, linting, and build on your rebased branch. If anything fails, fix it before proceeding. Do not merge a branch that has not been verified against the latest main.
 
 ### 7. Ensure CI is green

--- a/tasks/demo-review.md
+++ b/tasks/demo-review.md
@@ -54,7 +54,15 @@ Use `AskUserQuestion` to present:
 
 If the user's response mentions creating issues, tracking follow-ups, or requests that new work be recorded (e.g., "create an issue for X", "track this as a follow-up", "make a ticket for Y"): extract each request as a follow-up issue with a title and description derived from the user's wording.
 
-**Approved** → merge the PR into `main` (squash merge preferred). Mark the issue as Done in the product development management system.
+**Approved** → before merging, check that the PR has no merge conflicts:
+
+```bash
+gh pr view <pr_url> --json mergeable,mergeStateStatus
+```
+
+If `mergeable` is `CONFLICTING` or `mergeStateStatus` is `DIRTY`, do **not** attempt to merge. Instead, post a `demo-review-complete` comment with `outcome: redirect` and `user_feedback: "PR has merge conflicts and cannot be merged. The branch must be rebased onto main and conflicts resolved before merging."`, then report to `team-manager` with the same outcome and user_feedback. Stop here.
+
+If the PR is mergeable, proceed to merge it into `main` (squash merge preferred). Mark the issue as Done in the product development management system.
 
 **Redirect** → do NOT merge. Mark the issue status as **In Progress** in the product development management system.
 

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -28,6 +28,14 @@ Read all comments on the PM issue using the product development management syste
 - Check if a branch for this issue already exists locally (e.g. `git branch --list "*<issue-id>*"` or check `../worktrees/`).
 - Check if a PR is already open on the remote: `gh pr list --search "<issue-id>" --state open`.
 - If a PR exists, check CI status: `gh pr checks <pr_url>`.
+- If a PR exists, check for merge conflicts:
+
+```bash
+gh pr view <pr_url> --json mergeable,mergeStateStatus
+```
+
+Note whether `mergeable` is `CONFLICTING` (or `mergeStateStatus` is `DIRTY`) — used in the routing table below.
+
 - If a PR exists, count unresolved review threads and collect their bodies:
 
 ```bash
@@ -61,6 +69,7 @@ Use the most recent comment of each type from Step 2, combined with git/PR state
 | `test-complete outcome: pass`, not stale | PR open, CI green | `demo-review` — skip Phase 1 |
 | `test-complete outcome: pass`, **stale** | PR open | `code` — issue updated since test; re-plan in Phase 1 |
 | `test-complete outcome: fail` | PR open | `code` — fix findings on the existing branch; run Phase 1 with `findings` |
+| `task-complete` exists | PR open, **merge conflicts** | `code` — rebase and resolve conflicts; run Phase 1 with merge conflict details as `findings` |
 | `task-complete` exists | PR open, CI green, **unresolved review threads** | `code` — resolve review threads first; run Phase 1 with thread bodies as `findings` |
 | `task-complete` exists | PR open, CI green | `test` — skip Phase 1 |
 | `task-complete` exists | No open PR, or PR CI failing | `code` — lost artifact or broken CI; re-plan in Phase 1 |


### PR DESCRIPTION
## Summary

Fixes #12 — the system was presenting PRs with merge conflicts as ready to merge.

- **`tasks/code.md`**: Step 6 (rebase) now explicitly instructs agents to resolve conflicts during rebase or report `task-failed` if the resolution is ambiguous. Previously, the text was vague and agents could proceed past conflicts.
- **`tasks/plan.md`**: Adds a `gh pr view --json mergeable,mergeStateStatus` check in the git/PR state assessment step, plus a new routing row that routes to `code` when a PR has merge conflicts (`CONFLICTING`/`DIRTY` state).
- **`tasks/demo-review.md`**: Adds an explicit mergeability check before any approved PR is merged. If `mergeable=CONFLICTING`, the task redirects back to code instead of attempting to merge.
- **`evals/test_static.py`**: Adds `TestMergeConflictHandling` class (4 tests) and 2 new routing table coverage tests to prevent regressions.
- **`evals/test_plan_routing.py`**: Adds a new LLM eval scenario for the merge-conflict routing case.

## Test plan

- [x] All 45 static tests pass (`python3 -m pytest evals/test_static.py -v`)
- [ ] LLM eval scenarios pass (requires `OPENROUTER_API_KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)