### PR TITLE
Add session persistence with config file and SessionStart hook (#16)

### DIFF
--- a/config/default-config.json
+++ b/config/default-config.json
@@ -1,0 +1,4 @@
+{
+  "project_url": null,
+  "system": null
+}

--- a/docs/hooks-discovery.md
+++ b/docs/hooks-discovery.md
@@ -138,10 +138,9 @@ exit 0
 #!/bin/bash
 CONFIG_FILE="$CLAUDE_PROJECT_DIR/.claude/product-team/config.json"
 if [ -f "$CONFIG_FILE" ]; then
-  REPO=$(jq -r '.repo // empty' "$CONFIG_FILE")
-  PM=$(jq -r '.pm_system // empty' "$CONFIG_FILE")
-  PROJECT=$(jq -r '.project_id // empty' "$CONFIG_FILE")
-  jq -n --arg ctx "Project config: repo=$REPO, pm_system=$PM, project_id=$PROJECT" \
+  REPO=$(jq -r '.project_url // empty' "$CONFIG_FILE")
+  PM=$(jq -r '.system // empty' "$CONFIG_FILE")
+  jq -n --arg ctx "Project config: project_url=$REPO, system=$PM" \
     '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
 fi
 exit 0

--- a/evals/test_static.py
+++ b/evals/test_static.py
@@ -466,6 +466,17 @@ class TestSessionPersistence:
             "team-manager.md must skip asking when saved config exists"
         )
 
+    def test_session_hook_reads_correct_config_fields(self):
+        """The SessionStart hook must read the same field names defined in default-config.json."""
+        config_path = REPO_ROOT / "config" / "default-config.json"
+        config_data = json.loads(config_path.read_text())
+        hook_content = load_file("hooks/load-session-context.sh")
+        for field in config_data:
+            assert f".{field}" in hook_content, (
+                f"load-session-context.sh must read .{field} from config "
+                f"(field defined in default-config.json)"
+            )
+
     def test_status_shows_config_state(self):
         content = load_file("lib/install.js")
         assert "configStatus" in content or "config" in content.lower(), (

--- a/evals/test_static.py
+++ b/evals/test_static.py
@@ -9,7 +9,9 @@ These tests verify that the task definition files are internally consistent:
 - The team manager handles every report type any task can produce
 - Every task and role specifies the correct model in its frontmatter
 - The installer configures the TeammateIdle hook to stop idle teammates
+- Session persistence config and hooks are properly defined
 """
+import json
 import re
 from pathlib import Path
 
@@ -404,4 +406,68 @@ class TestIdleTeammateHook:
         content = load_file("roles/team-manager.md")
         assert "TeammateIdle" in content or "idle" in content.lower(), (
             "roles/team-manager.md must document that idle team members are removed after reporting"
+        )
+
+
+class TestSessionPersistence:
+    """Session persistence: config file, SessionStart hook, and manager startup."""
+
+    def test_default_config_exists(self):
+        config_path = REPO_ROOT / "config" / "default-config.json"
+        assert config_path.exists(), "config/default-config.json template must exist"
+
+    def test_default_config_is_valid_json(self):
+        config_path = REPO_ROOT / "config" / "default-config.json"
+        content = config_path.read_text()
+        data = json.loads(content)
+        assert "project_url" in data, "default-config.json must contain project_url field"
+        assert "system" in data, "default-config.json must contain system field"
+
+    def test_config_in_install_manifest(self):
+        content = load_file("lib/install.js")
+        assert "config/default-config.json" in content, (
+            "install.js MANIFEST must include config/default-config.json"
+        )
+        assert ".claude/product-team/config.json" in content, (
+            "install.js must install config to .claude/product-team/config.json"
+        )
+
+    def test_session_start_hook_in_settings(self):
+        content = load_file("lib/install.js")
+        assert "SessionStart" in content, (
+            "install.js REQUIRED_SETTINGS must include a SessionStart hook"
+        )
+
+    def test_config_in_package_files(self):
+        content = load_file("package.json")
+        data = json.loads(content)
+        assert "config/" in data.get("files", []), (
+            "package.json files array must include config/"
+        )
+
+    def test_manager_reads_saved_config(self):
+        content = load_file("roles/team-manager.md")
+        assert "config.json" in content, (
+            "team-manager.md startup must reference config.json"
+        )
+        assert "project_url" in content, (
+            "team-manager.md startup must reference project_url from saved config"
+        )
+
+    def test_manager_saves_config_on_first_run(self):
+        content = load_file("roles/team-manager.md")
+        assert re.search(r"[Ss]ave.*config", content), (
+            "team-manager.md must instruct saving config on first run"
+        )
+
+    def test_manager_skips_asking_when_config_exists(self):
+        content = load_file("roles/team-manager.md")
+        assert re.search(r"skip.*asking|only if no saved config", content, re.IGNORECASE), (
+            "team-manager.md must skip asking when saved config exists"
+        )
+
+    def test_status_shows_config_state(self):
+        content = load_file("lib/install.js")
+        assert "configStatus" in content or "config" in content.lower(), (
+            "status() function must display config state"
         )

--- a/hooks/load-session-context.sh
+++ b/hooks/load-session-context.sh
@@ -10,12 +10,11 @@ if [ ! -f "$CONFIG_FILE" ]; then
   exit 0
 fi
 
-REPO=$(jq -r '.repo // empty' "$CONFIG_FILE")
-PM=$(jq -r '.pm_system // empty' "$CONFIG_FILE")
-PROJECT=$(jq -r '.project_id // empty' "$CONFIG_FILE")
+REPO=$(jq -r '.project_url // empty' "$CONFIG_FILE")
+PM=$(jq -r '.system // empty' "$CONFIG_FILE")
 
-if [ -n "$REPO" ] || [ -n "$PM" ] || [ -n "$PROJECT" ]; then
-  CONTEXT="Project config: repo=$REPO, pm_system=$PM, project_id=$PROJECT"
+if [ -n "$REPO" ] || [ -n "$PM" ]; then
+  CONTEXT="Project config: project_url=$REPO, system=$PM"
   jq -n --arg ctx "$CONTEXT" \
     '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
 fi

--- a/lib/install.js
+++ b/lib/install.js
@@ -19,6 +19,7 @@ const MANIFEST = [
   { src: 'hooks/guard-worktree-discipline.sh', dest: '.claude/hooks/guard-worktree-discipline.sh', mode: 0o755 },
   { src: 'hooks/load-session-context.sh',   dest: '.claude/hooks/load-session-context.sh',   mode: 0o755 },
   { src: 'hooks/log-agent-event.sh',        dest: '.claude/hooks/log-agent-event.sh',        mode: 0o755 },
+  { src: 'config/default-config.json',   dest: '.claude/product-team/config.json', skipOverwrite: true },
 ];
 
 function rewriteTaskPaths(content) {
@@ -26,6 +27,8 @@ function rewriteTaskPaths(content) {
 }
 
 const SETTINGS_PATH = '.claude/settings.json';
+
+const CONFIG_PATH = '.claude/product-team/config.json';
 
 const REQUIRED_SETTINGS = {
   env: { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1' },
@@ -71,6 +74,15 @@ const REQUIRED_SETTINGS = {
             type: 'command',
             command: '.claude/hooks/load-session-context.sh',
             timeout: 10,
+          },
+        ],
+      },
+      {
+        matcher: '',
+        hooks: [
+          {
+            type: 'command',
+            command: `test -f .claude/product-team/config.json && node -e "const c=JSON.parse(require('fs').readFileSync('.claude/product-team/config.json','utf8')); process.exit(c.project_url ? 0 : 1)" && echo "Session config loaded. Use the team-manager skill to continue working on the product."`,
           },
         ],
       },
@@ -180,6 +192,11 @@ async function run({ force = false, dryRun = false } = {}) {
     const destPath = path.join(projectRoot, entry.dest);
     const exists = fs.existsSync(destPath);
 
+    if (exists && entry.skipOverwrite) {
+      results.push({ dest: entry.dest, action: dryRun ? 'skip (preserved)' : 'preserved' });
+      continue;
+    }
+
     if (exists && !force && !overwriteAll) {
       if (dryRun) {
         results.push({ dest: entry.dest, action: 'skip (exists)' });
@@ -251,6 +268,22 @@ function status() {
   }
   console.log(`  [${settingsOk ? '✓' : '✗'}] ${SETTINGS_PATH} (agent teams settings)`);
   console.log(`  [${hooksOk ? '✓' : '✗'}] ${SETTINGS_PATH} (hooks configuration)`);
+
+  const configPath = path.join(projectRoot, CONFIG_PATH);
+  let configStatus = 'not configured';
+  if (fs.existsSync(configPath)) {
+    try {
+      const c = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      if (c.project_url) {
+        configStatus = `${c.system} — ${c.project_url}`;
+      } else {
+        configStatus = 'present but no project URL saved';
+      }
+    } catch {
+      configStatus = 'invalid JSON';
+    }
+  }
+  console.log(`  [${configStatus !== 'not configured' && configStatus !== 'present but no project URL saved' && configStatus !== 'invalid JSON' ? '✓' : '✗'}] ${CONFIG_PATH} (${configStatus})`);
   console.log('');
 }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "files": [
     "bin/",
+    "config/",
     "hooks/",
     "lib/",
     "roles/",

--- a/roles/team-manager.md
+++ b/roles/team-manager.md
@@ -17,9 +17,10 @@ You maintain a set of **task definitions** (in the `tasks/` folder). Each task d
 
 When you first start, do the following:
 
-1. **Ask the user which product development management system they use** — Request the system name (e.g. Linear, Jira, GitHub Issues) and the project URL or identifier.
-2. **Delegate an issue triage task** — Spawn a team member with `tasks/issue-triage.md` and pass them the product development management system and project identifier. Wait for their triage report before doing anything else.
-3. **Act on the triage report** — Once the triage comes back, delegate a planning task for the `next_issue` from the report.
+1. **Check for saved configuration** — Read `.claude/product-team/config.json` if it exists. If `project_url` is already saved (non-null), skip asking the user and proceed directly to step 3 using the saved `system` and `project_url`.
+2. **Ask the user (only if no saved config)** — If the config file does not exist or `project_url` is null, ask the user which product development management system they use. Request the system name (e.g. Linear, Jira, GitHub Issues) and the project URL or identifier. Save the system name and project URL to `.claude/product-team/config.json` so future sessions can skip this step.
+3. **Delegate an issue triage task** — Spawn a team member with `tasks/issue-triage.md` and pass them the product development management system and project identifier. Wait for their triage report before doing anything else.
+4. **Act on the triage report** — Once the triage comes back, delegate a planning task for the `next_issue` from the report.
 
 ## Responsibilities
 


### PR DESCRIPTION
## Summary

- Saves project URL and system name to `.claude/product-team/config.json` so returning sessions skip the setup prompt and proceed directly to issue triage
- Adds a `SessionStart` hook to `.claude/settings.json` that detects saved config on session launch and prompts the user to invoke the team-manager skill
- Updates `status()` to display current config state (project URL saved or not)
- Adds 9 new static eval tests covering config file existence, install manifest, hook presence, manager startup behavior, and package inclusion

Closes #16

## Test plan

- [x] All 48 static eval tests pass (`python evals/test_static.py`)
- [ ] Manual: run `npx autonomous-product-team init` in a test project and verify config.json is created
- [ ] Manual: verify SessionStart hook appears in `.claude/settings.json` after install
- [ ] Manual: verify team-manager reads saved config and skips asking on subsequent sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)