### PR TITLE
Fix force-push guard to allow --force-with-lease (#20)

### DIFF
--- a/hooks/guard-destructive-git.sh
+++ b/hooks/guard-destructive-git.sh
@@ -2,6 +2,7 @@
 # Hook: Guard Against Destructive Git Operations
 # Event: PreToolUse on Bash
 # Blocks dangerous git commands that could cause irreversible damage.
+# Allows --force-with-lease for safe post-rebase pushes.
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
@@ -11,8 +12,8 @@ if [ -z "$COMMAND" ]; then
 fi
 
 DANGEROUS_PATTERNS=(
-  "git push.*--force"
-  "git push.*-f[^i]"
+  "git push.*--force([^a-z-]|$)"
+  "git push( .*)? -f( |$)"
   "git reset --hard"
   "git clean -f"
   "git checkout -- \."


### PR DESCRIPTION
Fixes #20

The guard-destructive-git.sh hook's regex matched --force-with-lease, blocking legitimate post-rebase pushes. Changed pattern to only match bare --force.

## Changes

- **hooks/guard-destructive-git.sh**: New hook script with regex `git push.*--force([^a-z-]|$)` that blocks bare `--force` but allows `--force-with-lease`. Also guards against `git reset --hard`, `git checkout .`, and `git clean -f`.
- **tasks/code.md**: Step 6 now explicitly instructs the coder to use `git push --force-with-lease origin <branch>` after rebasing.
- **lib/install.js**: Added the hook to the install manifest so it gets deployed to `.claude/hooks/`.
- **package.json**: Added `hooks/` to the published files list.