### PR TITLE
Configure orchestrator via web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ evals/.venv/
 __pycache__/
 *.pyc
 .pytest_cache/
+tmp/
 
 # autonomous-product-team
 orchestrator-state.json
+

--- a/README.md
+++ b/README.md
@@ -27,29 +27,16 @@ npx @alysonbasilio/autonomous-product-team run
 
 This installs any missing files and starts the orchestrator:
 - `tasks/` — 8 task definitions (issue-triage, discovery, plan, code, test, demo-review, create-issue, status-correction)
-- `product-team.config.json` — project configuration (edit this before running; never overwritten by `--force`)
 
 It also appends `orchestrator-state.json` to your `.gitignore`.
 
-Before starting, edit `product-team.config.json`:
+The orchestrator UI is available at `http://localhost:4242`. On first run, the UI shows a setup form for:
 
-```json
-{
-  "project_url": "https://linear.app/your-team/issues",
-  "system": "Linear"
-}
-```
+- **project_url** — URL of your issues list (e.g. `https://linear.app/your-team/issues`)
+- **tenant** — your Synthup tenant id
+- **api_key** — your Synthup API key
 
-`system` is the name of your issue management system (e.g. `"GitHub Issues"`, `"Linear"`). `project_url` points to your issues list in that system.
-
-Set your Synthup credentials:
-
-```bash
-export SYNTHUP_API_KEY=<your-api-key>
-export SYNTHUP_TENANT=<your-tenant-id>
-```
-
-The orchestrator UI is available at `http://localhost:4242`.
+These values are persisted in `orchestrator-state.json` and reused on restart.
 
 To update task definitions to the latest version:
 

--- a/config/default-config.json
+++ b/config/default-config.json
@@ -1,4 +1,0 @@
-{
-  "project_url": null,
-  "system": null
-}

--- a/lib/install.js
+++ b/lib/install.js
@@ -12,7 +12,6 @@ const MANIFEST = [
   { src: 'tasks/discovery.md',         dest: 'tasks/discovery.md' },
   { src: 'tasks/status-correction.md', dest: 'tasks/status-correction.md' },
   { src: 'tasks/test.md',              dest: 'tasks/test.md' },
-  { src: 'config/default-config.json', dest: 'product-team.config.json', skipOverwrite: true },
 ];
 
 const GITIGNORE_ENTRIES = [
@@ -88,28 +87,22 @@ function status() {
     console.log(`  [${exists ? '✓' : '✗'}] ${entry.dest}`);
   }
 
-  const configPath = path.join(projectRoot, 'product-team.config.json');
-  let configStatus = 'not configured';
-  if (fs.existsSync(configPath)) {
+  const statePath = path.join(projectRoot, 'orchestrator-state.json');
+  let configStatus = 'not configured (set via web UI)';
+  if (fs.existsSync(statePath)) {
     try {
-      const c = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-      if (c.project_url) {
-        configStatus = `${c.system} — ${c.project_url}`;
-      } else {
-        configStatus = 'present but no project URL saved';
+      const s = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+      const c = s.config;
+      const required = ['project_url', 'tenant', 'api_key'];
+      if (c && required.every(k => c[k])) {
+        configStatus = c.project_url;
       }
     } catch {
-      configStatus = 'invalid JSON';
+      configStatus = 'invalid state file';
     }
   }
-  const configOk = configStatus !== 'not configured' && configStatus !== 'present but no project URL saved' && configStatus !== 'invalid JSON';
-  console.log(`  [${configOk ? '✓' : '✗'}] product-team.config.json (${configStatus})`);
-
-  const apiKeyOk = !!(process.env.SYNTHUP_API_KEY);
-  console.log(`  [${apiKeyOk ? '✓' : '✗'}] SYNTHUP_API_KEY (${apiKeyOk ? 'set' : 'not set'})`);
-
-  const synthupTenantOk = !!(process.env.SYNTHUP_TENANT);
-  console.log(`  [${synthupTenantOk ? '✓' : '✗'}] SYNTHUP_TENANT (${synthupTenantOk ? 'set' : 'not set'})`);
+  const configOk = configStatus.startsWith('not configured') === false && configStatus !== 'invalid state file';
+  console.log(`  [${configOk ? '✓' : '✗'}] orchestrator config (${configStatus})`);
 
   const gitignorePath = path.join(projectRoot, '.gitignore');
   const gitignoreOk = fs.existsSync(gitignorePath) &&

--- a/orchestrator/run.rb
+++ b/orchestrator/run.rb
@@ -16,31 +16,9 @@ require_relative 'task_runner'
 require_relative 'demo_review'
 require_relative 'server'
 
-# ── Startup checks ────────────────────────────────────────────────────────────
-
-project_root = Dir.pwd
-config_path  = File.join(project_root, 'product-team.config.json')
-
-unless File.exist?(config_path)
-  abort "config not found: #{config_path}\nRun: npx autonomous-product-team init"
-end
-
-config = JSON.parse(File.read(config_path))
-
-unless ENV['SYNTHUP_API_KEY']
-  abort 'Set the SYNTHUP_API_KEY environment variable before running the orchestrator.'
-end
-
-unless ENV['SYNTHUP_TENANT']
-  abort 'Set the SYNTHUP_TENANT environment variable before running the orchestrator.'
-end
-
-unless config['project_url']
-  abort "project_url is not set in #{config_path}"
-end
-
 # ── Start web server ──────────────────────────────────────────────────────────
 
+project_root = Dir.pwd
 port   = (ENV['ORCHESTRATOR_PORT'] || 4242).to_i
 OrchestratorServer.project_root = project_root
 server = OrchestratorServer  # class used as handle; state is class-level
@@ -61,6 +39,19 @@ end
 # ── Load or initialise state ──────────────────────────────────────────────────
 
 state = State.load(project_root) || State.initial
+
+# ── Wait for configuration via UI ─────────────────────────────────────────────
+
+unless OrchestratorServer.config_complete?(state['config'])
+  puts "Waiting for configuration at http://localhost:#{port} …"
+  until OrchestratorServer.config_complete?(state['config'])
+    sleep 1
+    state = State.load(project_root) || State.initial
+  end
+end
+
+config = state['config']
+Synthup.api_key = config['api_key']
 
 if state['status'] == 'escalated'
   esc = state['escalation'] || {}
@@ -94,14 +85,11 @@ def dispatch_task(config, project_root, task, context)
 
   task_path = TaskRunner.find_task_file(task, project_root)
   model     = TaskRunner.parse_model(task_path)
-  full_context = {
-    'system'      => config['system'],
-    'project_url' => config['project_url']
-  }.merge(context)
+  full_context = { 'project_url' => config['project_url'] }.merge(context)
   prompt = TaskRunner.compose_prompt(task_path, full_context)
 
   session = Synthup.create_session(
-    tenant:  ENV['SYNTHUP_TENANT'],
+    tenant:  config['tenant'],
     project: github_repo(config['project_url']),
     prompt:  prompt,
     model:   model

--- a/orchestrator/server.rb
+++ b/orchestrator/server.rb
@@ -1,10 +1,13 @@
 require 'sinatra/base'
 require 'json'
 require_relative 'state'
+require_relative 'synthup'
 
 class OrchestratorServer < Sinatra::Base
   set :server, :puma
   set :logging, false
+
+  CONFIG_KEYS = %w[project_url tenant api_key].freeze
 
   # Class-level state — shared across all per-request instances
   class << self
@@ -27,11 +30,22 @@ class OrchestratorServer < Sinatra::Base
     {
       status:           s['status'],
       paused:           paused,
+      configured:       config_complete?(s['config']),
+      config:           redacted_config(s['config']),
       currentTask:      s['currentTask'],
       history:          (s['history'] || []).last(20),
       escalation:       s['escalation'],
       pending_approval: approval_meta
     }
+  end
+
+  def self.config_complete?(cfg)
+    cfg.is_a?(Hash) && CONFIG_KEYS.all? { |k| cfg[k].to_s.strip != '' }
+  end
+
+  def self.redacted_config(cfg)
+    return nil unless cfg.is_a?(Hash)
+    cfg.merge('api_key' => cfg['api_key'] ? '••••' : nil)
   end
 
   # ── Routes ─────────────────────────────────────────────────────────────────
@@ -61,6 +75,15 @@ class OrchestratorServer < Sinatra::Base
     pa[:resolve].call('outcome' => 'redirect',
                       'user_feedback' => body_params['user_feedback'] || '',
                       'follow_up_issues' => nil)
+    json_ok
+  end
+
+  post '/api/config' do
+    body_params = JSON.parse(request.body.read) rescue {}
+    cfg = CONFIG_KEYS.each_with_object({}) { |k, h| h[k] = body_params[k].to_s.strip }
+    return json_error(400, 'All fields are required') unless self.class.config_complete?(cfg)
+    State.patch(self.class.project_root, 'config' => cfg)
+    Synthup.api_key = cfg['api_key']
     json_ok
   end
 

--- a/orchestrator/state.rb
+++ b/orchestrator/state.rb
@@ -10,6 +10,7 @@ module State
     {
       'version'    => 1,
       'status'     => 'running',
+      'config'     => nil,
       'currentTask'=> nil,
       'escalation' => nil,
       'history'    => []

--- a/orchestrator/synthup.rb
+++ b/orchestrator/synthup.rb
@@ -5,6 +5,10 @@ require 'uri'
 module Synthup
   BASE = 'https://www.synthup.dev'
 
+  class << self
+    attr_accessor :api_key
+  end
+
   class Error < StandardError
     attr_reader :status, :body
     def initialize(status, body)
@@ -45,16 +49,15 @@ module Synthup
 
   private
 
-  def self.api_key
-    key = ENV['SYNTHUP_API_KEY']
-    raise 'SYNTHUP_API_KEY environment variable is not set' unless key
-    key
+  def self.auth_key
+    raise 'Synthup API key is not configured' unless @api_key
+    @api_key
   end
 
   def self.get(path)
     uri = URI("#{BASE}#{path}")
     req = Net::HTTP::Get.new(uri)
-    req['Authorization'] = "Bearer #{api_key}"
+    req['Authorization'] = "Bearer #{auth_key}"
     req['Accept'] = 'application/json'
     request(uri, req)
   end
@@ -62,7 +65,7 @@ module Synthup
   def self.post(path, body)
     uri = URI("#{BASE}#{path}")
     req = Net::HTTP::Post.new(uri)
-    req['Authorization'] = "Bearer #{api_key}"
+    req['Authorization'] = "Bearer #{auth_key}"
     req['Content-Type'] = 'application/json'
     req['Accept'] = 'application/json'
     req.body = body.to_json

--- a/orchestrator/ui.html
+++ b/orchestrator/ui.html
@@ -131,6 +131,17 @@
   }
   textarea:focus { outline: 1px solid var(--blue); }
 
+  input[type="text"], input[type="password"], input:not([type]) {
+    font-family: inherit;
+    font-size: 12px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    color: var(--text);
+    padding: .35rem .5rem;
+  }
+  input:focus { outline: 1px solid var(--blue); }
+
   .follow-ups-toggle {
     font-size: 11px;
     color: var(--muted);
@@ -185,6 +196,17 @@
     </div>
   </div>
 </header>
+
+<!-- Setup -->
+<section id="setup" class="hidden">
+  <h2>Setup</h2>
+  <div style="color:var(--muted);margin-bottom:.75rem">Configure the orchestrator before it starts running.</div>
+  <div class="row"><span class="label">project_url</span><input id="cfg-project_url" placeholder="https://linear.app/your-team/issues" style="flex:1"></div>
+  <div class="row"><span class="label">tenant</span><input id="cfg-tenant" placeholder="your-tenant-id" style="flex:1"></div>
+  <div class="row"><span class="label">api_key</span><input id="cfg-api_key" type="password" placeholder="Synthup API key" style="flex:1"></div>
+  <div id="cfg-error" style="color:var(--red);margin-top:.5rem;display:none"></div>
+  <div class="btn-row"><button class="primary" onclick="saveConfig()">Save</button></div>
+</section>
 
 <!-- Current task -->
 <section id="current-task-section">
@@ -243,6 +265,14 @@
 
   function applyState(s) {
     state = s;
+
+    // Setup form (shown until configured)
+    const setup = document.getElementById('setup');
+    if (s.configured) {
+      setup.classList.add('hidden');
+    } else {
+      setup.classList.remove('hidden');
+    }
 
     // Status badge
     const badge = document.getElementById('status-badge');
@@ -314,6 +344,29 @@
   }
 
   // ── Actions ────────────────────────────────────────────────────────────────
+
+  function saveConfig() {
+    const cfg = {
+      project_url: document.getElementById('cfg-project_url').value.trim(),
+      tenant:      document.getElementById('cfg-tenant').value.trim(),
+      api_key:     document.getElementById('cfg-api_key').value.trim()
+    };
+    const err = document.getElementById('cfg-error');
+    if (Object.values(cfg).some(v => !v)) {
+      err.textContent = 'All fields are required.';
+      err.style.display = 'block';
+      return;
+    }
+    err.style.display = 'none';
+    fetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(cfg)
+    }).then(r => r.json()).then(j => {
+      if (j.error) { err.textContent = j.error; err.style.display = 'block'; }
+      else { document.getElementById('cfg-api_key').value = ''; }
+    }).catch(() => {});
+  }
 
   function approve() {
     const followUpsRaw = document.getElementById('dr-followups').value.trim();

--- a/product-team.config.json
+++ b/product-team.config.json
@@ -1,4 +1,0 @@
-{
-  "project_url": "https://github.com/AlysonBasilio/autonomous-product-team/issues",
-  "system": "GitHub Issues"
-}


### PR DESCRIPTION
## Summary
- Replace `SYNTHUP_API_KEY` / `SYNTHUP_TENANT` env vars and `product-team.config.json` with a setup form in the orchestrator UI at `http://localhost:4242`. Values (project_url, tenant, api_key) persist in `orchestrator-state.json` and are reused on restart.
- Drop the `system` config field — tasks did not branch on it, so LLMs infer the issue tracker from `project_url` alone.
- Add `POST /api/config`; api_key is redacted in `/api/state`.

## Test plan
- [ ] Delete `orchestrator-state.json`, run the orchestrator, confirm the UI shows three inputs (project_url, tenant, api_key) and the orchestrator does not dispatch any task until the form is submitted.
- [ ] Submit the form, confirm the form disappears and triage starts.
- [ ] Restart the orchestrator and confirm it does not re-prompt (config loaded from state).
- [ ] Inspect a composed task prompt and confirm it contains `project_url:` and no longer contains `system:`.
- [ ] Run `npx @alysonbasilio/autonomous-product-team status` and confirm the orchestrator-config line shows the URL with no broken interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)