### PR TITLE
Fix UI: show proper issue display and fix history '?' for planning task (#36)

### DIFF
--- a/orchestrator/run.rb
+++ b/orchestrator/run.rb
@@ -170,11 +170,15 @@ loop do
   end
 
   # Record history (store only a compact summary of the report)
-  started_at = state.dig('currentTask', 'started_at')
+  # Reload state here so we capture the currentTask that was set by dispatch_task —
+  # the local `state` variable may be stale if dispatch_task ran in the current iteration.
+  current_task_state = State.load(project_root)
+  started_at = current_task_state.dig('currentTask', 'started_at') ||
+               state.dig('currentTask', 'started_at')
   duration   = started_at ? (Time.now - Time.parse(started_at)).round : nil
   State.record_history(project_root, {
-    'task'         => state.dig('currentTask', 'task'),
-    'session_id'   => state.dig('currentTask', 'session_id'),
+    'task'         => current_task_state.dig('currentTask', 'task') || state.dig('currentTask', 'task'),
+    'session_id'   => current_task_state.dig('currentTask', 'session_id') || state.dig('currentTask', 'session_id'),
     'completed_at' => Time.now.utc.iso8601,
     'duration_s'   => duration,
     'report'       => { 'type'     => report['type'],

--- a/orchestrator/ui.html
+++ b/orchestrator/ui.html
@@ -290,7 +290,7 @@
       const elapsed = ct.started_at ? formatElapsed(ct.started_at) : '—';
       ctSection.innerHTML = `
         <div class="row"><span class="label">task</span><span class="value">${esc(ct.task)}</span></div>
-        ${ct.context?.issue_id ? `<div class="row"><span class="label">issue</span><span class="value">${esc(ct.context.issue_id)}</span></div>` : ''}
+        ${ct.context?.issue_id ? `<div class="row"><span class="label">issue</span><span class="value">${esc(issueDisplay(ct.context.issue_id))}</span></div>` : ''}
         ${ct.context?.pr_url   ? `<div class="row"><span class="label">PR</span><span class="value"><a href="${esc(ct.context.pr_url)}" target="_blank">${esc(ct.context.pr_url)}</a></span></div>` : ''}
         <div class="row"><span class="label">elapsed</span><span class="value" id="elapsed-value">${elapsed}</span></div>
         ${ct.session_id ? `<div class="row"><span class="label">session</span><span class="value">${sessionLink(ct.session_id)}</span></div>` : ''}
@@ -333,11 +333,13 @@
     const el = document.getElementById('history-list');
     if (!items.length) { el.innerHTML = '<span class="empty">No completed tasks yet</span>'; return; }
     el.innerHTML = [...items].reverse().map(h => {
-      const icon = outcomeIcon(h.outcome || h.report?.type);
-      const dur  = h.duration_s ? `${h.duration_s}s` : '';
+      const icon    = outcomeIcon(h.outcome || h.report?.type);
+      const dur     = h.duration_s ? `${h.duration_s}s` : '';
+      const taskStr = h.task ? h.task.replace(/\.md$/, '') : (h.report?.type || '?');
+      const issueId = h.report?.issue_id ? ` · ${issueDisplay(h.report.issue_id)}` : '';
       return `<div class="history-item">
         <span class="history-icon">${icon}</span>
-        <span class="history-task">${esc(h.task || '?')}</span>
+        <span class="history-task">${esc(taskStr)}${esc(issueId)}</span>
         <span class="history-meta">${esc(dur)}</span>
       </div>`;
     }).join('');
@@ -411,6 +413,17 @@
       headers: { 'Content-Type': 'application/json' },
       body: body ? JSON.stringify(body) : undefined
     }).catch(() => {});
+  }
+
+  function issueDisplay(issueId) {
+    if (issueId == null) return '';
+    if (typeof issueId === 'object') {
+      // next_issue is passed as { id, title, summary } from triage-report
+      const id    = issueId.id    || '';
+      const title = issueId.title || '';
+      return title ? `${id} — ${title}` : id;
+    }
+    return String(issueId);
   }
 
   function sessionLink(sessionId) {


### PR DESCRIPTION
## Problem

Two UI bugs were reported in issue #36:

1. **`[object Object]` in the "issue" field** of the Current Task panel when the planning task is running. The triage-report passes `next_issue` as a full JSON object `{ id, title, summary }` and router.rb stores it as `context.issue_id`. When `ui.html` called `esc(ct.context.issue_id)`, JavaScript coerced the object to the string `"[object Object]"`.

2. **`?` in the History panel** for task names. The history is recorded using the local `state` variable loaded at the top of each loop iteration. When `dispatch_task` is called in the `else` branch (no active session), or when a `pending_report` is consumed from a previous iteration, `state.currentTask` is `nil`/stale, so `h.task` was `nil` → displayed as `"?"`.

## Fix

**`orchestrator/ui.html`**:
- Added `issueDisplay()` helper that handles `issue_id` being either a plain string (normal case) or an object `{ id, title, summary }` (triage → plan routing). It renders as `"ID — Title"` when an object, or the string as-is otherwise.
- Updated `renderHistory()` to strip the `.md` suffix from task names for cleaner display, fall back to `report.type` when `task` is missing, and append `issue_id` to each history entry.

**`orchestrator/run.rb`**:
- Before recording history, reload the state file so `currentTask.task` and `started_at` reflect what `dispatch_task` just set — fixing the stale-local-variable issue that caused `'?'` task names.

Closes #36